### PR TITLE
Feat/mutates array in update job

### DIFF
--- a/src/Jobs/UpdateJob.php
+++ b/src/Jobs/UpdateJob.php
@@ -84,6 +84,8 @@ final class UpdateJob
                 continue;
             }
 
+            $array = $this->mutateArray($searchable, $array);
+
             $array['_tags'] = (array) ($array['_tags'] ?? []);
 
             array_push($array['_tags'], ObjectIdEncrypter::encrypt($searchable));
@@ -191,5 +193,38 @@ final class UpdateJob
     private function usesSoftDelete($searchable): bool
     {
         return $searchable instanceof Model && in_array(SoftDeletes::class, class_uses_recursive($searchable), true);
+    }
+
+    /**
+     * Mutate the given array using searchable's model attributes.
+     *
+     * @param  object  $searchable
+     * @param  array  $array
+     *
+     * @return array
+     */
+    private function mutateArray($searchable, array $array): array
+    {
+        foreach ($array as $key => $value) {
+            $attributeValue = $searchable->getModel()->getAttribute($key);
+
+            /**
+             * Casts carbon instances to timestamp.
+             */
+            if ($attributeValue instanceof \Illuminate\Support\Carbon) {
+                $array[$key] = $attributeValue->getTimestamp();
+            }
+
+            /**
+             * Casts numeric strings to integers/floats.
+             */
+            if (is_string($attributeValue) && is_numeric($attributeValue)) {
+                $array[$key] = ctype_digit($attributeValue)
+                    ? (int) $attributeValue
+                    : (float) $attributeValue;
+            }
+        }
+
+        return $array;
     }
 }


### PR DESCRIPTION
**Issue**: By default, Laravel sends everything to Algolia as string. This means, if the user runs the `php artisan scout:optimize`, the detected custom ranking may not work.

This Pull Request **proposes apply a mutation to the `object`** before sending it to Algolia. Converting numeric values to integers/floats and converting dates to timestamps.

Previously at Algolia Index:
```
likes_count:	"113"
created_at:	"2018-11-16 21:25:18"
updated_at:	"2018-11-16 21:25:18"
```
After at Algolia Index:
```
likes_count:	113
created_at:	1542403518
updated_at:	1542403518
```