### PR TITLE
[0.3] Adds support to complex where conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Support to `<`, `<=`, `=`, `!=`, `>=`, `>` operators in `Builder::where` method
 
 ## [0.2.0] - 2018-11-16
 ### Added

--- a/README.md
+++ b/README.md
@@ -232,7 +232,17 @@ echo get_class($models[1]); // "App\Event"
 
 ## 🏗 Builder Macros
 
-Scout Extended adds a few methods to the Laravel Scout's builder class.
+Scout Extended improves Laravel Scout's Builder class.
+
+#### Improved `where()`
+
+The `where()` supports `<`, `<=`, `=`, `!=`, `>=`, `>` operators:
+
+```php
+$models = Article::search('query')->where('views', '> 100'); // views > 100
+$models = Article::search('query')->where('views <=', '100'); // views <= 100
+$models = Article::search('query')->where('views', '100'); // views = 100
+```
 
 #### `count()`
 

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -100,4 +100,20 @@ class AlgoliaEngine extends BaseAlgoliaEngine
 
         $index->clearObjects();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function filters(Builder $builder): array
+    {
+        $operators = ['<', '<=', '=', '!=', '>=', '>'];
+
+        return collect($builder->wheres)->map(function ($value, $key) use ($operators) {
+            if (ends_with($key, $operators) || starts_with($value, $operators)) {
+                return $key.' '.$value;
+            }
+
+            return $key.'='.$value;
+        })->values()->all();
+    }
 }

--- a/tests/Features/WhereQueriesTest.php
+++ b/tests/Features/WhereQueriesTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features;
+
+use App\User;
+use Tests\TestCase;
+
+final class WhereQueriesTest extends TestCase
+{
+    public function testOperators(): void
+    {
+        $this->mockIndex(User::class)->shouldReceive('search')->with('foo', [
+            'numericFilters' => [
+                'views_count > 100',
+            ],
+        ])->andReturn(['hits' => []]);
+
+        User::search('foo')->where('views_count', '> 100')->get();
+    }
+
+    public function testEqualOperator(): void
+    {
+        $this->mockIndex(User::class)->shouldReceive('search')->with('foo', [
+            'numericFilters' => [
+                'views_count=100',
+            ],
+        ])->andReturn(['hits' => []]);
+
+        User::search('foo')->where('views_count', '100')->get();
+    }
+}


### PR DESCRIPTION
This Pull Request adds Laravel Scout's Builder class adding support to complex where conditions.

The `where()` now supports `<`, `<=`, `=`, `!=`, `>=`, `>` operators:

```php
$models = Article::search('query')->where('views', '> 100'); // views > 100
$models = Article::search('query')->where('views <=', '100'); // views <= 100
$models = Article::search('query')->where('views', '100'); // views = 100
```