### PR TITLE
ci: use vm-based travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-sudo: false
-
 php:
   - 7.1
   - 7.2


### PR DESCRIPTION
Will become the default: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

safe to merge If tests are 🍏 