### PR TITLE
Added configurable settings path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/*
+.phpintel
 composer.lock
 /vendor/

--- a/src/Repositories/LocalSettingsRepository.php
+++ b/src/Repositories/LocalSettingsRepository.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare (strict_types = 1);
 
 /**
  * This file is part of Scout Extended.
@@ -13,11 +13,10 @@ declare(strict_types=1);
 
 namespace Algolia\ScoutExtended\Repositories;
 
-use function is_array;
-use Illuminate\Support\Str;
-use Illuminate\Filesystem\Filesystem;
 use Algolia\AlgoliaSearch\SearchIndex;
 use Algolia\ScoutExtended\Settings\Settings;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 
 /**
  * @internal
@@ -71,17 +70,15 @@ final class LocalSettingsRepository
 
         $name = is_array($name) ? current($name) : $name;
 
-        $fileName = 'scout-'.Str::lower($name).'.php';
+        $fileName = 'scout-' . Str::lower($name) . '.php';
+        $settingsPath = config('scout.algolia.settings_path');
 
-        if (config('scout.algolia.settings_path')) {
-            if (! $this->files->exists(config('scout.algolia.settings_path'))) {
-                $this->files->makeDirectory(config('scout.algolia.settings_path'), 0755, true);
+        if ($settingsPath) {
+            if (!$this->files->exists($settingsPath)) {
+                $this->files->makeDirectory($settingsPath, 0755, true);
             }
 
-            return implode(DIRECTORY_SEPARATOR, [
-                config('scout.algolia.settings_path'),
-                $fileName,
-            ]);
+            return $settingsPath . DIRECTORY_SEPARATOR . $fileName;
         }
 
         return config_path($fileName);

--- a/src/Repositories/LocalSettingsRepository.php
+++ b/src/Repositories/LocalSettingsRepository.php
@@ -70,7 +70,7 @@ final class LocalSettingsRepository
         $name = str_replace('_', '-', $index->getIndexName());
 
         $name = is_array($name) ? current($name) : $name;
-        
+
         if (config('scout.settings_path')) {
             if (! $this->files->exists(config('scout.settings_path'))) {
                 $this->files->makeDirectory(config('scout.settings_path'), 0755, true);

--- a/src/Repositories/LocalSettingsRepository.php
+++ b/src/Repositories/LocalSettingsRepository.php
@@ -71,18 +71,20 @@ final class LocalSettingsRepository
 
         $name = is_array($name) ? current($name) : $name;
 
+        $fileName = 'scout-'.Str::lower($name).'.php';
+
         if (config('scout.algolia.settings_path')) {
-            if (! $this->files->exists(config('scout.algolia.settings_path'))) {
+            if (!$this->files->exists(config('scout.algolia.settings_path'))) {
                 $this->files->makeDirectory(config('scout.algolia.settings_path'), 0755, true);
             }
 
             return implode(DIRECTORY_SEPARATOR, [
                 config('scout.algolia.settings_path'),
-                'scout-'.Str::lower($name).'.php',
+                $fileName,
             ]);
         }
 
-        return config_path('scout-'.Str::lower($name).'.php');
+        return config_path($fileName);
     }
 
     /**

--- a/src/Repositories/LocalSettingsRepository.php
+++ b/src/Repositories/LocalSettingsRepository.php
@@ -72,7 +72,7 @@ final class LocalSettingsRepository
         $name = is_array($name) ? current($name) : $name;
         
         if (config('scout.settings_path')) {
-            if (!$this->files->exists(config('scout.settings_path'))) {
+            if (! $this->files->exists(config('scout.settings_path'))) {
                 $this->files->makeDirectory(config('scout.settings_path'), 0755, true);
             }
 

--- a/src/Repositories/LocalSettingsRepository.php
+++ b/src/Repositories/LocalSettingsRepository.php
@@ -73,15 +73,15 @@ final class LocalSettingsRepository
         $fileName = 'scout-'.Str::lower($name).'.php';
         $settingsPath = config('scout.algolia.settings_path');
 
-        if ($settingsPath) {
-            if (! $this->files->exists($settingsPath)) {
-                $this->files->makeDirectory($settingsPath, 0755, true);
-            }
-
-            return $settingsPath.DIRECTORY_SEPARATOR.$fileName;
+        if ($settingsPath === null) {
+            return config_path($fileName);
         }
 
-        return config_path($fileName);
+        if (! $this->files->exists($settingsPath)) {
+            $this->files->makeDirectory($settingsPath, 0755, true);
+        }
+
+        return $settingsPath.DIRECTORY_SEPARATOR.$fileName;
     }
 
     /**

--- a/src/Repositories/LocalSettingsRepository.php
+++ b/src/Repositories/LocalSettingsRepository.php
@@ -71,7 +71,7 @@ final class LocalSettingsRepository
 
         $name = is_array($name) ? current($name) : $name;
 
-        if (config('scout.settings_path')) {
+        if (config('scout.algolia.settings_path')) {
             if (! $this->files->exists(config('scout.algolia.settings_path'))) {
                 $this->files->makeDirectory(config('scout.algolia.settings_path'), 0755, true);
             }

--- a/src/Repositories/LocalSettingsRepository.php
+++ b/src/Repositories/LocalSettingsRepository.php
@@ -74,7 +74,7 @@ final class LocalSettingsRepository
         $fileName = 'scout-'.Str::lower($name).'.php';
 
         if (config('scout.algolia.settings_path')) {
-            if (!$this->files->exists(config('scout.algolia.settings_path'))) {
+            if (! $this->files->exists(config('scout.algolia.settings_path'))) {
                 $this->files->makeDirectory(config('scout.algolia.settings_path'), 0755, true);
             }
 

--- a/src/Repositories/LocalSettingsRepository.php
+++ b/src/Repositories/LocalSettingsRepository.php
@@ -1,6 +1,6 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
 
 /**
  * This file is part of Scout Extended.
@@ -13,10 +13,10 @@ declare (strict_types = 1);
 
 namespace Algolia\ScoutExtended\Repositories;
 
+use Illuminate\Support\Str;
+use Illuminate\Filesystem\Filesystem;
 use Algolia\AlgoliaSearch\SearchIndex;
 use Algolia\ScoutExtended\Settings\Settings;
-use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
 
 /**
  * @internal
@@ -70,15 +70,15 @@ final class LocalSettingsRepository
 
         $name = is_array($name) ? current($name) : $name;
 
-        $fileName = 'scout-' . Str::lower($name) . '.php';
+        $fileName = 'scout-'.Str::lower($name).'.php';
         $settingsPath = config('scout.algolia.settings_path');
 
         if ($settingsPath) {
-            if (!$this->files->exists($settingsPath)) {
+            if (! $this->files->exists($settingsPath)) {
                 $this->files->makeDirectory($settingsPath, 0755, true);
             }
 
-            return $settingsPath . DIRECTORY_SEPARATOR . $fileName;
+            return $settingsPath.DIRECTORY_SEPARATOR.$fileName;
         }
 
         return config_path($fileName);

--- a/src/Repositories/LocalSettingsRepository.php
+++ b/src/Repositories/LocalSettingsRepository.php
@@ -72,12 +72,12 @@ final class LocalSettingsRepository
         $name = is_array($name) ? current($name) : $name;
 
         if (config('scout.settings_path')) {
-            if (! $this->files->exists(config('scout.settings_path'))) {
-                $this->files->makeDirectory(config('scout.settings_path'), 0755, true);
+            if (! $this->files->exists(config('scout.algolia.settings_path'))) {
+                $this->files->makeDirectory(config('scout.algolia.settings_path'), 0755, true);
             }
 
             return implode(DIRECTORY_SEPARATOR, [
-                config('scout.settings_path'),
+                config('scout.algolia.settings_path'),
                 'scout-'.Str::lower($name).'.php',
             ]);
         }

--- a/src/Repositories/LocalSettingsRepository.php
+++ b/src/Repositories/LocalSettingsRepository.php
@@ -70,6 +70,17 @@ final class LocalSettingsRepository
         $name = str_replace('_', '-', $index->getIndexName());
 
         $name = is_array($name) ? current($name) : $name;
+        
+        if (config('scout.settings_path')) {
+            if (!$this->files->exists(config('scout.settings_path'))) {
+                $this->files->makeDirectory(config('scout.settings_path'), 0755, true);
+            }
+
+            return implode(DIRECTORY_SEPARATOR, [
+                config('scout.settings_path'),
+                'scout-'.Str::lower($name).'.php',
+            ]);
+        }
 
         return config_path('scout-'.Str::lower($name).'.php');
     }

--- a/tests/Features/OptimizeCommandTest.php
+++ b/tests/Features/OptimizeCommandTest.php
@@ -21,6 +21,22 @@ final class OptimizeCommandTest extends TestCase
         $this->assertLocalHas($this->local());
     }
 
+    public function testCreationOfLocalSettingsWithCustomPath(): void
+    {
+        config(['scout.algolia.settings_path' => config_path('algolia')]);
+
+        factory(User::class)->create();
+
+        $this->mockIndex(User::class, $this->defaults());
+
+        Artisan::call('scout:optimize', ['searchable' => User::class, '--no-interaction']);
+
+        $this->assertLocalHas($this->local(), 'algolia/scout-users.php');
+
+        unlink(config_path('algolia/scout-users.php'));
+        rmdir(config_path('algolia'));
+    }
+
     public function testThatRequiresARowOnTheDatabase(): void
     {
         $this->mockIndex(User::class, $this->defaults());

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -74,10 +74,10 @@ class TestCase extends BaseTestCase
         return $defaults;
     }
 
-    protected function assertLocalHas(array $settings): void
+    protected function assertLocalHas(array $settings, string $settings_path = 'scout-users.php'): void
     {
-        $this->assertFileExists(config_path('scout-users.php'));
-        $this->assertEquals($settings, require config_path('scout-users.php'));
+        $this->assertFileExists(config_path($settings_path));
+        $this->assertEquals($settings, require config_path($settings_path));
     }
 
     protected function local(): array

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -74,10 +74,10 @@ class TestCase extends BaseTestCase
         return $defaults;
     }
 
-    protected function assertLocalHas(array $settings, string $settings_path = 'scout-users.php'): void
+    protected function assertLocalHas(array $settings, string $settingsPath = 'scout-users.php'): void
     {
-        $this->assertFileExists(config_path($settings_path));
-        $this->assertEquals($settings, require config_path($settings_path));
+        $this->assertFileExists(config_path($settingsPath));
+        $this->assertEquals($settings, require config_path($settingsPath));
     }
 
     protected function local(): array


### PR DESCRIPTION
Added a setting to `config/scout.php` enabling Algolia's index settings to be stored in a configurable location. 
Closes #118

Documentation needs updating to include this new option.
There are no tests to update.