### PR TITLE
Make sure we run shoudlBeSearchable() on the correct class

### DIFF
--- a/src/Searchable/Aggregator.php
+++ b/src/Searchable/Aggregator.php
@@ -171,9 +171,9 @@ abstract class Aggregator implements SearchableCountableContract
             $instance->newQuery()->when($softDeletes, function ($query) {
                 $query->withTrashed();
             })->orderBy($instance->getKeyName())->chunk(config('scout.chunk.searchable', 500), function ($models) {
-                $models = $models->map(function ($model) {
+                $models = $models->filter->shouldBeSearchable()->map(function ($model) {
                     return static::create($model);
-                })->filter->shouldBeSearchable();
+                });
 
                 $models->searchable();
 


### PR DESCRIPTION
[See my comments here](https://github.com/algolia/scout-extended/pull/62#discussion_r248746900) regarding this on PR #62 

This may also be related issue #103 

**TL:DR**
Before this change, `shouldBeSearchable()` was called on the `Aggregator` class rather than the `Model` when running `artisan scout:import` or `artisan scout:reimport`, meaning that all Models were always imported whether they `shouldBeSearchable` or not