### PR TITLE
Add missing ext-dom php extension dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^7.1.3",
+        "ext-dom": "*",
         "ext-json": "*",
         "algolia/algoliasearch-client-php": "^2.0",
         "illuminate/console": "5.6.*|5.7.*",


### PR DESCRIPTION
Add missing `ext-dom` extension as a pendency.

See https://github.com/algolia/scout-extended/blob/2cd4d70bc0addf587a680cb83b7380b8afb16ea4/src/Splitters/HtmlSplitter.php#L16