### PR TITLE
Adds prefix option to optimize command, fixes #123

### DIFF
--- a/src/Console/Commands/OptimizeCommand.php
+++ b/src/Console/Commands/OptimizeCommand.php
@@ -26,7 +26,7 @@ final class OptimizeCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected $signature = 'scout:optimize {searchable? : The name of the searchable}';
+    protected $signature = 'scout:optimize {searchable? : The name of the searchable} {--prefix=}';
 
     /**
      * {@inheritdoc}
@@ -43,6 +43,9 @@ final class OptimizeCommand extends Command
         SearchableFinder $searchableFinder,
         LocalSettingsRepository $localRepository
     ) {
+        if ($prefix = $this->option('prefix')) {
+            config(['scout.prefix' => $prefix]);
+        }
         foreach ($searchableFinder->fromCommand($this) as $searchable) {
             $this->output->text('🔎 Optimizing search experience in: <info>['.$searchable.']</info>');
             $index = $algolia->index($searchable);

--- a/src/Console/Commands/OptimizeCommand.php
+++ b/src/Console/Commands/OptimizeCommand.php
@@ -26,7 +26,9 @@ final class OptimizeCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected $signature = 'scout:optimize {searchable? : The name of the searchable} {--prefix=}';
+    protected $signature = 'scout:optimize 
+                            {searchable? : The name of the searchable} 
+                            {--prefix= : A custom `scout.prefix` configuration key}';
 
     /**
      * {@inheritdoc}

--- a/src/Console/Commands/SyncCommand.php
+++ b/src/Console/Commands/SyncCommand.php
@@ -27,7 +27,8 @@ final class SyncCommand extends Command
      */
     protected $signature = 'scout:sync
                             {searchable? : The name of the searchable}
-                            {--keep=none} : In conflict keep the given option';
+                            {--keep=none} : In conflict keep the given option
+                            {--prefix= : A custom `scout.prefix` configuration key}';
 
     /**
      * {@inheritdoc}
@@ -45,6 +46,10 @@ final class SyncCommand extends Command
     ): void {
         foreach ($searchableFinder->fromCommand($this) as $searchable) {
             $this->output->text('🔎 Analysing settings from: <info>['.$searchable.']</info>');
+            if ($prefix = $this->option('prefix')) {
+                $originalPrefix = config('scout.prefix');
+                config(['scout.prefix' => $prefix]);
+            }
             $status = $synchronizer->analyse($index = $algolia->index($searchable));
             $path = $localRepository->getPath($index);
 
@@ -107,6 +112,9 @@ final class SyncCommand extends Command
                             break;
                     }
                     break;
+            }
+            if (isset($originalPrefix)) {
+                config(['scout.prefix' => $originalPrefix]);
             }
         }
 

--- a/tests/Features/OptimizeCommandTest.php
+++ b/tests/Features/OptimizeCommandTest.php
@@ -45,4 +45,20 @@ final class OptimizeCommandTest extends TestCase
 
         $this->assertFileNotExists(config_path('scout-users.php'));
     }
+
+    public function testCreationOfLocalSettingsWithCustomPrefix(): void
+    {
+        factory(User::class)->create();
+
+        $prefix = config('scout.prefix');
+        config(['scout.prefix' => 'custom_']);
+        $this->mockIndex(User::class, $this->defaults());
+        config(['scout.prefix' => $prefix]);
+
+        Artisan::call('scout:optimize', ['searchable' => User::class, '--prefix' => 'custom_']);
+
+        $this->assertLocalHas($this->local(), config_path('scout-custom-users.php'));
+
+        unlink(config_path('scout-custom-users.php'));
+    }
 }


### PR DESCRIPTION
Adds a prefix option to the optimize command, to allow for generating index configurations for another environment than the one we're currently developing in.

In response to: https://github.com/algolia/scout-extended/issues/123