### PR TITLE
Fixes bug whereby a collection could not be made unsearchable.

### DIFF
--- a/src/Jobs/DeleteJob.php
+++ b/src/Jobs/DeleteJob.php
@@ -53,9 +53,11 @@ final class DeleteJob
         $index = $client->initIndex($this->searchables->first()->searchableAs());
 
         $result = $index->deleteBy([
-            'tagFilters' => $this->searchables->map(function ($searchable) {
-                return ObjectIdEncrypter::encrypt($searchable);
-            })->toArray(),
+            'tagFilters' => [
+                $this->searchables->map(function ($searchable) {
+                    return ObjectIdEncrypter::encrypt($searchable);
+                })->toArray()
+            ],
         ]);
 
         if (config('scout.synchronous', false)) {

--- a/tests/Features/AggregatorTest.php
+++ b/tests/Features/AggregatorTest.php
@@ -27,7 +27,7 @@ final class AggregatorTest extends TestCase
 
         $usersIndexMock->shouldReceive('deleteBy')->once()->with([
             'tagFilters' => [
-                'App\User::1',
+                ['App\User::1'],
             ],
         ]);
 
@@ -53,13 +53,13 @@ final class AggregatorTest extends TestCase
 
         $usersIndexMock->shouldReceive('deleteBy')->once()->with([
             'tagFilters' => [
-                'App\User::1',
+                ['App\User::1'],
             ],
         ]);
 
         $wallIndexMock->shouldReceive('deleteBy')->once()->with([
             'tagFilters' => [
-                'App\User::1',
+                ['App\User::1'],
             ],
         ]);
 
@@ -82,13 +82,13 @@ final class AggregatorTest extends TestCase
 
         $threadIndexMock->shouldReceive('deleteBy')->once()->with([
             'tagFilters' => [
-                'App\Thread::1',
+                ['App\Thread::1'],
             ],
         ]);
 
         $wallIndexMock->shouldReceive('deleteBy')->once()->with([
             'tagFilters' => [
-                'App\Thread::1',
+                ['App\Thread::1'],
             ],
         ]);
         $thread->delete();
@@ -107,7 +107,7 @@ final class AggregatorTest extends TestCase
         }));
         $wallIndexMock->shouldReceive('deleteBy')->times(3)->with([
             'tagFilters' => [
-                'App\Post::1',
+                ['App\Post::1'],
             ],
         ]);
         $post = factory(Post::class)->create();
@@ -134,7 +134,7 @@ final class AggregatorTest extends TestCase
 
         $wallIndexMock->shouldReceive('deleteBy')->once()->with([
             'tagFilters' => [
-                'App\Post::1',
+                ['App\Post::1'],
             ],
         ]);
         $post->forceDelete();

--- a/tests/Features/SplittersTest.php
+++ b/tests/Features/SplittersTest.php
@@ -27,7 +27,7 @@ final class SplittersTest extends TestCase
 
         $index->shouldReceive('deleteBy')->once()->with([
             'tagFilters' => [
-                'Tests\Features\Fixtures\ThreadWithSplitterClass::1',
+                ['Tests\Features\Fixtures\ThreadWithSplitterClass::1'],
             ],
         ]);
 
@@ -52,7 +52,7 @@ final class SplittersTest extends TestCase
 
         $index->shouldReceive('deleteBy')->with([
             'tagFilters' => [
-                'Tests\Features\Fixtures\ThreadWithValueReturned::1',
+                ['Tests\Features\Fixtures\ThreadWithValueReturned::1'],
             ],
         ]);
 
@@ -77,7 +77,7 @@ final class SplittersTest extends TestCase
 
         $index->shouldReceive('deleteBy')->with([
             'tagFilters' => [
-                'Tests\Features\Fixtures\ThreadWithSplitterInstance::1',
+                ['Tests\Features\Fixtures\ThreadWithSplitterInstance::1'],
             ],
         ]);
 
@@ -118,7 +118,7 @@ final class SplittersTest extends TestCase
 
         $index->shouldReceive('deleteBy')->with([
             'tagFilters' => [
-                'Tests\Features\Fixtures\ThreadMultipleSplits::1',
+                ['Tests\Features\Fixtures\ThreadMultipleSplits::1'],
             ],
         ]);
 


### PR DESCRIPTION
Hi @nunomaduro 

This fixes [142](https://github.com/algolia/scout-extended/issues/142). 

`unsearchable()` will now work on collections as well. Let me know if anything else is needed.

Thanks a lot! 