### PR TITLE
Fixes 154 whereby _rankingInfo and _highlightResult were being indexed.

### DIFF
--- a/src/Jobs/UpdateJob.php
+++ b/src/Jobs/UpdateJob.php
@@ -18,11 +18,13 @@ use function in_array;
 use function is_array;
 use function get_class;
 use function is_string;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Algolia\AlgoliaSearch\SearchClient;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Algolia\ScoutExtended\Searchable\ModelsResolver;
 use Algolia\ScoutExtended\Contracts\SplitterContract;
 use Algolia\ScoutExtended\Searchable\ObjectIdEncrypter;
 use Algolia\ScoutExtended\Transformers\ConvertDatesToTimestamps;
@@ -102,7 +104,9 @@ final class UpdateJob
         $searchablesToDelete = [];
 
         foreach ($this->searchables as $key => $searchable) {
-            if (empty($array = array_merge($searchable->toSearchableArray(), $searchable->scoutMetadata()))) {
+            $metadata = Arr::except($searchable->scoutMetadata(), ModelsResolver::$metadata);
+
+            if (empty($array = array_merge($searchable->toSearchableArray(), $metadata))) {
                 continue;
             }
 

--- a/src/Searchable/ModelsResolver.php
+++ b/src/Searchable/ModelsResolver.php
@@ -29,7 +29,7 @@ final class ModelsResolver
     /**
      * @var string[]
      */
-    private static $metadata = [
+    public static $metadata = [
         '_highlightResult',
         '_rankingInfo',
     ];

--- a/tests/Features/SearchableTest.php
+++ b/tests/Features/SearchableTest.php
@@ -7,6 +7,8 @@ namespace Tests\Features;
 use Mockery;
 use App\User;
 use Tests\TestCase;
+use Illuminate\Support\Arr;
+use Algolia\ScoutExtended\Searchable\ModelsResolver;
 
 final class SearchableTest extends TestCase
 {
@@ -17,9 +19,11 @@ final class SearchableTest extends TestCase
         $user->withScoutMetaData('_rankingInfo', []);
         $user->withScoutMetaData('_highlightResult', []);
 
+        $metadataKeys = ModelsResolver::$metadata;
+
         $usersIndex = $this->mockIndex(User::class);
-        $usersIndex->expects('saveObjects')->once()->with(Mockery::on(function ($argument) {
-            return ! in_array('_rankingInfo', $argument[0]) && ! in_array('_highlightResult', $argument[0]);
+        $usersIndex->expects('saveObjects')->once()->with(Mockery::on(function ($argument) use($metadataKeys) {
+            return count(Arr::only($argument[0], $metadataKeys)) === 0;
         }));
 
         $user->searchable();

--- a/tests/Features/SearchableTest.php
+++ b/tests/Features/SearchableTest.php
@@ -22,7 +22,7 @@ final class SearchableTest extends TestCase
         $metadataKeys = ModelsResolver::$metadata;
 
         $usersIndex = $this->mockIndex(User::class);
-        $usersIndex->expects('saveObjects')->once()->with(Mockery::on(function ($argument) use($metadataKeys) {
+        $usersIndex->expects('saveObjects')->once()->with(Mockery::on(function ($argument) use ($metadataKeys) {
             return count(Arr::only($argument[0], $metadataKeys)) === 0;
         }));
 

--- a/tests/Features/SearchableTest.php
+++ b/tests/Features/SearchableTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare (strict_types = 1);
+
+namespace Tests\Features;
+
+use Mockery;
+use App\User;
+use Tests\TestCase;
+
+final class SearchableTest extends TestCase
+{
+    public function testSearchable(): void
+    {
+        $user = factory(User::class)->create();
+
+        $user->withScoutMetaData('_rankingInfo', []);
+        $user->withScoutMetaData('_highlightResult', []);
+
+        $usersIndex = $this->mockIndex(User::class);
+        $usersIndex->expects('saveObjects')->once()->with(Mockery::on(function ($argument) {
+            return !in_array('_rankingInfo', $argument[0]) && !in_array('_highlightResult', $argument[0]);
+        }));
+
+        $user->searchable();
+    }
+}

--- a/tests/Features/SearchableTest.php
+++ b/tests/Features/SearchableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
 
 namespace Tests\Features;
 
@@ -19,7 +19,7 @@ final class SearchableTest extends TestCase
 
         $usersIndex = $this->mockIndex(User::class);
         $usersIndex->expects('saveObjects')->once()->with(Mockery::on(function ($argument) {
-            return !in_array('_rankingInfo', $argument[0]) && !in_array('_highlightResult', $argument[0]);
+            return ! in_array('_rankingInfo', $argument[0]) && ! in_array('_highlightResult', $argument[0]);
         }));
 
         $user->searchable();


### PR DESCRIPTION
Hi @nunomaduro 

This PR fixes #154. I made the `$metadata` property public and used `Arr::except()` in the update job to remove those keys if it is present in the array. 

**Edit**: I also added a SearchableTest which validates a `searchable()` action without indexing the `_rankingInfo` and `_highlightResult` keys. Let me know if anything else is needed for this. 
