### PR TITLE
Lumen support

### DIFF
--- a/src/Console/Commands/OptimizeCommand.php
+++ b/src/Console/Commands/OptimizeCommand.php
@@ -60,7 +60,7 @@ final class OptimizeCommand extends Command
                 $compiler->compile($settings, $path);
                 $this->output->success('Settings file created at: '.$path);
                 $this->output->note('Please review the settings file and synchronize it with Algolia using: "'.
-                    ARTISAN_BINARY.' scout:sync"');
+                    $this->getApplication()->artisanBinary().' scout:sync"');
             }
         }
     }

--- a/src/Console/Commands/OptimizeCommand.php
+++ b/src/Console/Commands/OptimizeCommand.php
@@ -15,6 +15,7 @@ namespace Algolia\ScoutExtended\Console\Commands;
 
 use Illuminate\Console\Command;
 use Algolia\ScoutExtended\Algolia;
+use Illuminate\Console\Application;
 use Algolia\ScoutExtended\Settings\Compiler;
 use Algolia\ScoutExtended\Settings\LocalFactory;
 use Algolia\ScoutExtended\Helpers\SearchableFinder;
@@ -60,7 +61,7 @@ final class OptimizeCommand extends Command
                 $compiler->compile($settings, $path);
                 $this->output->success('Settings file created at: '.$path);
                 $this->output->note('Please review the settings file and synchronize it with Algolia using: "'.
-                    $this->getApplication()->artisanBinary().' scout:sync"');
+                    Application::artisanBinary().' scout:sync"');
             }
         }
     }

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -87,7 +87,7 @@ class AlgoliaEngine extends BaseAlgoliaEngine
             return $searchable->newCollection();
         }
 
-        return resolve(ModelsResolver::class)->from($builder, $searchable, $results);
+        return app(ModelsResolver::class)->from($builder, $searchable, $results);
     }
 
     /**

--- a/src/Helpers/SearchableFinder.php
+++ b/src/Helpers/SearchableFinder.php
@@ -17,7 +17,6 @@ use function in_array;
 use Illuminate\Support\Str;
 use Laravel\Scout\Searchable;
 use Illuminate\Console\Command;
-use Illuminate\Container\Container;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 
@@ -32,17 +31,17 @@ final class SearchableFinder
     private static $declaredClasses;
 
     /**
-     * @var \Illuminate\Container\Container
+     * @var \Illuminate\Contracts\Foundation\Application
      */
     private $app;
 
     /**
      * SearchableModelsFinder constructor.
      *
-     * @param \Illuminate\Container\Container $app
+     * @param \Illuminate\Contracts\Foundation\Application $app
      * @return void
      */
-    public function __construct(Container $app)
+    public function __construct($app)
     {
         $this->app = $app;
     }

--- a/src/Helpers/SearchableFinder.php
+++ b/src/Helpers/SearchableFinder.php
@@ -17,8 +17,8 @@ use function in_array;
 use Illuminate\Support\Str;
 use Laravel\Scout\Searchable;
 use Illuminate\Console\Command;
+use Illuminate\Container\Container;
 use Symfony\Component\Finder\Finder;
-use Illuminate\Foundation\Application;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 
 /**
@@ -32,18 +32,17 @@ final class SearchableFinder
     private static $declaredClasses;
 
     /**
-     * @var \Illuminate\Foundation\Application
+     * @var \Illuminate\Container\Container
      */
     private $app;
 
     /**
      * SearchableModelsFinder constructor.
      *
-     * @param \Illuminate\Foundation\Application $app
-     *
+     * @param \Illuminate\Container\Container $app
      * @return void
      */
-    public function __construct(Application $app)
+    public function __construct(Container $app)
     {
         $this->app = $app;
     }

--- a/src/Repositories/LocalSettingsRepository.php
+++ b/src/Repositories/LocalSettingsRepository.php
@@ -74,7 +74,7 @@ final class LocalSettingsRepository
         $settingsPath = config('scout.algolia.settings_path');
 
         if ($settingsPath === null) {
-            return config_path($fileName);
+            return app('path.config').DIRECTORY_SEPARATOR.$fileName;
         }
 
         if (! $this->files->exists($settingsPath)) {

--- a/src/ScoutExtendedServiceProvider.php
+++ b/src/ScoutExtendedServiceProvider.php
@@ -20,6 +20,7 @@ use Algolia\ScoutExtended\Jobs\UpdateJob;
 use Algolia\AlgoliaSearch\AnalyticsClient;
 use Algolia\ScoutExtended\Engines\AlgoliaEngine;
 use Algolia\ScoutExtended\Managers\EngineManager;
+use Algolia\ScoutExtended\Helpers\SearchableFinder;
 use Algolia\ScoutExtended\Console\Commands\SyncCommand;
 use Algolia\ScoutExtended\Console\Commands\FlushCommand;
 use Algolia\ScoutExtended\Searchable\AggregatorObserver;
@@ -89,6 +90,10 @@ final class ScoutExtendedServiceProvider extends ServiceProvider
 
         $this->app->singleton(AggregatorObserver::class, AggregatorObserver::class);
         $this->app->bind(\Laravel\Scout\Builder::class, Builder::class);
+
+        $this->app->bind(SearchableFinder::class, function () {
+            return new SearchableFinder($this->app);
+        });
     }
 
     /**

--- a/src/Searchable/Aggregator.php
+++ b/src/Searchable/Aggregator.php
@@ -57,7 +57,7 @@ abstract class Aggregator implements SearchableCountableContract
     {
         ($self = new static)->registerSearchableMacros();
 
-        $observer = tap(resolve(AggregatorObserver::class))->setAggregator(static::class, $models = $self->getModels());
+        $observer = tap(app(AggregatorObserver::class))->setAggregator(static::class, $models = $self->getModels());
 
         foreach ($models as $model) {
             $model::observe($observer);


### PR DESCRIPTION
Hi

PR adds support of Lumen #56. 
1. It replaces helpers that are incompatible with Lumen. Lumen supports limited [list](https://github.com/laravel/lumen-framework/blob/master/src/helpers.php) of `Illuminate\Foundation\helpers`. 
2. Helper class `SearchableFinder` uses `\Illuminate\Foundation\Application` as DI now. Lumen uses own extension of Container -  `Laravel\Lumen\Application`.  So I added `Illuminate\Container\Container` class as DI (not sure about it).

In spite of the fixes extra Lumen specific setup steps are still required. Maybe it is worth to add these steps to the documentation. Something like that:

Enable Eloquent and Facades if you plan to use it:

```php
// bootstrap/app.php:
$app->withFacades();
$app->withEloquent();
```

Bind path to the configuration directory with the IOC container:

```php
// bootstrap/app.php
$app->instance('path.config', base_path('config'));
```

Manually copy configuration file from `vendor/laravel/scout/config/scout.php`  to `config/scout.php`.

Load configuration file into the application:

```php
// bootstrap/app.php
$app->configure('scout');
```

Register service provider:

```php
// bootstrap/app.php:
$app->register(Algolia\ScoutExtended\ScoutExtendedServiceProvider::class);
```