### PR TITLE
Add test for aggregator transforms

### DIFF
--- a/tests/Features/Fixtures/ThreadAggregatorUsingOnlyDateTransform.php
+++ b/tests/Features/Fixtures/ThreadAggregatorUsingOnlyDateTransform.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Features\Fixtures;
+
+use Algolia\ScoutExtended\Searchable\Aggregator;
+
+class ThreadAggregatorUsingOnlyDateTransform extends Aggregator
+{
+    protected $models = [
+        ThreadWithSearchableArrayUsingDateTransform::class,
+    ];
+}

--- a/tests/Features/Fixtures/ThreadWithSearchableArrayUsingDateTransform.php
+++ b/tests/Features/Fixtures/ThreadWithSearchableArrayUsingDateTransform.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Features\Fixtures;
+
+use App\Thread;
+use Algolia\ScoutExtended\Transformers\ConvertDatesToTimestamps;
+
+class ThreadWithSearchableArrayUsingDateTransform extends Thread
+{
+    protected  $table = 'threads';
+
+    public function toSearchableArray(): array
+    {
+        $data = array_merge($this->toArray(), ['subscriber_count' => '100']);
+        return $this->transform($data, [
+            ConvertDatesToTimestamps::class,
+        ]);
+    }
+}


### PR DESCRIPTION
@nunomaduro this is the failing test for #158 

You'll note that we've setup an extended "Thread" model where the toSearchableArray method specifies to only use the date transform.

The `testModelTransformsAreRespectedOnAggregators` test then fails, as while the following check passes on the single model, it fails on the aggregate as the `'100'` has been cast to `100`.

```php
return $argument[0]['subscriber_count'] === '100';
```

The test can be made to pass by adding the following function to our `ThreadAggregatorUsingOnlyDateTransform` class as this causes the check at https://github.com/algolia/scout-extended/blob/master/src/Jobs/UpdateJob.php#L113 to pass and as such we don't call the default transformers again, however I feel a better fix would be an update in the `hasToSearchableArray method on `UpdateJobs`.

```php
public function toSearchableArray(): array
{
  return parent::toSearchableArray();
}
```