### PR TITLE
Enhance SearchableFinder to find searchable classes outside of app/

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/",
-            "App\\": "tests/laravel/app"
+            "App\\": "tests/laravel/app",
+            "Modules\\": "tests/laravel/modules"
         },
         "files": [
             "vendor/mockery/mockery/library/helpers.php"

--- a/tests/Features/FlushCommandTest.php
+++ b/tests/Features/FlushCommandTest.php
@@ -9,6 +9,7 @@ use App\News;
 use App\Thread;
 use App\User;
 use App\Wall;
+use Modules\Taxonomy\Term;
 use Tests\TestCase;
 
 final class FlushCommandTest extends TestCase
@@ -20,6 +21,7 @@ final class FlushCommandTest extends TestCase
         $this->mockIndex(Thread::class)->expects('clearObjects')->once();
         $this->mockIndex(Wall::class)->expects('clearObjects')->once();
         $this->mockIndex(EmptyItem::class)->expects('clearObjects')->once();
+        $this->mockIndex(Term::class)->expects('clearObjects')->once();
 
         /*
          * Detects searchable models.

--- a/tests/Features/ImportCommandTest.php
+++ b/tests/Features/ImportCommandTest.php
@@ -12,6 +12,7 @@ use App\Wall;
 use function count;
 use Illuminate\Support\Facades\Artisan;
 use Mockery;
+use Modules\Taxonomy\Term;
 use Tests\TestCase;
 
 final class ImportCommandTest extends TestCase
@@ -54,6 +55,9 @@ final class ImportCommandTest extends TestCase
         $emptyItemIndexMock = $this->mockIndex(EmptyItem::class);
         $emptyItemIndexMock->expects('clearObjects')->once();
         $emptyItemIndexMock->expects('saveObjects')->once()->with([]);
+
+        $termIndexMock = $this->mockIndex(Term::class);
+        $termIndexMock->expects('clearObjects')->once();
 
         Artisan::call('scout:import');
     }

--- a/tests/laravel/composer.json
+++ b/tests/laravel/composer.json
@@ -1,7 +1,8 @@
 {
     "autoload": {
         "psr-4": {
-            "App\\": "app/"
+            "App\\": "app/",
+            "Modules\\": "modules/"
         }
     }
 }

--- a/tests/laravel/database/migrations/2014_10_12_000003_create_terms_table.php
+++ b/tests/laravel/database/migrations/2014_10_12_000003_create_terms_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+final class CreateTermsTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('terms', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('slug');
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('terms');
+    }
+}

--- a/tests/laravel/modules/Taxonomy/Term.php
+++ b/tests/laravel/modules/Taxonomy/Term.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Modules\Taxonomy;
+
+use Laravel\Scout\Searchable;
+use Illuminate\Database\Eloquent\Model;
+
+class Term extends Model
+{
+    use Searchable;
+
+    protected $fillable = [
+        'name',
+        'slug',
+    ];
+}


### PR DESCRIPTION
Enhance SearchableFinder to find searchable classes outside of `app/` directory.

This change enables scout-extended to work with non-typical Laravel projects that have models stored in directories outside of `app/`.  For example a project that uses the [laravel-modules](https://github.com/nWidart/laravel-modules) library.

* `SearchableFinder` uses config (if present) in `config/scout.php`.  The existing behaviour has not changed.  I'm unsure if this is the best approach as it requires the end user to add config that is not present in the template `scout.php`.
* Tests modified to test the discovery of models located in the `laravel/modules` directory.  All tests passing.