### PR TITLE
Make wording clearer

### DIFF
--- a/src/Console/Commands/SyncCommand.php
+++ b/src/Console/Commands/SyncCommand.php
@@ -71,7 +71,7 @@ final class SyncCommand extends Command
                     $synchronizer->upload($index);
                     break;
                 case Status::BOTH_ARE_EQUAL:
-                    $this->output->success('Local and remote settings are similar.');
+                    $this->output->success('Local and remote settings match.');
                     break;
                 case Status::LOCAL_GOT_UPDATED:
                     if ($this->output->confirm('Local settings got updated. Wish to upload them?')) {


### PR DESCRIPTION
This threw me a little.

`similar` means the settings resemble each other, but are not necessarily the same.

This change makes it clearer that the settings on the `local` and `remote` are actually equal to each other.