### PR TITLE
Fix empty searchable array got indexed when soft delete meta data is enabled.

### DIFF
--- a/src/Jobs/UpdateJob.php
+++ b/src/Jobs/UpdateJob.php
@@ -106,9 +106,11 @@ final class UpdateJob
         foreach ($this->searchables as $key => $searchable) {
             $metadata = Arr::except($searchable->scoutMetadata(), ModelsResolver::$metadata);
 
-            if (empty($array = array_merge($searchable->toSearchableArray(), $metadata))) {
+            if (empty($searchable->toSearchableArray())) {
                 continue;
             }
+
+            $array = array_merge($searchable->toSearchableArray(), $metadata);
 
             if (! $this->hasToSearchableArray($searchable)) {
                 $array = $searchable->getModel()->transform($array);

--- a/src/Jobs/UpdateJob.php
+++ b/src/Jobs/UpdateJob.php
@@ -106,11 +106,11 @@ final class UpdateJob
         foreach ($this->searchables as $key => $searchable) {
             $metadata = Arr::except($searchable->scoutMetadata(), ModelsResolver::$metadata);
 
-            if (empty($searchable->toSearchableArray())) {
+            if (empty($searchableArray = $searchable->toSearchableArray())) {
                 continue;
             }
 
-            $array = array_merge($searchable->toSearchableArray(), $metadata);
+            $array = array_merge($searchableArray, $metadata);
 
             if (! $this->hasToSearchableArray($searchable)) {
                 $array = $searchable->getModel()->transform($array);

--- a/tests/Features/FlushCommandTest.php
+++ b/tests/Features/FlushCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Features;
 
+use App\EmptyItem;
 use App\News;
 use App\User;
 use App\Wall;
@@ -18,6 +19,7 @@ final class FlushCommandTest extends TestCase
         $this->mockIndex(User::class)->expects('clearObjects')->once();
         $this->mockIndex(Thread::class)->expects('clearObjects')->once();
         $this->mockIndex(Wall::class)->expects('clearObjects')->once();
+        $this->mockIndex(EmptyItem::class)->expects('clearObjects')->once();
 
         /*
          * Detects searchable models.

--- a/tests/Features/FlushCommandTest.php
+++ b/tests/Features/FlushCommandTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Features;
 
-use App\EmptyItem;
 use App\News;
 use App\User;
 use App\Wall;
 use App\Thread;
+use App\EmptyItem;
 use Tests\TestCase;
 
 final class FlushCommandTest extends TestCase

--- a/tests/Features/ImportCommandTest.php
+++ b/tests/Features/ImportCommandTest.php
@@ -21,7 +21,10 @@ final class ImportCommandTest extends TestCase
         Wall::bootSearchable();
         News::bootSearchable();
 
+        $this->app['config']->set('scout.soft_delete', true);
+
         factory(User::class, 5)->create();
+        factory(EmptyItem::class, 2)->create();
 
         // Detects searchable models.
         $userIndexMock = $this->mockIndex(User::class);
@@ -48,7 +51,9 @@ final class ImportCommandTest extends TestCase
         $threadIndexMock->expects('clearObjects')->once();
 
         // Detects searchable models.
-        $this->mockIndex(EmptyItem::class)->expects('clearObjects')->once();
+        $emptyItemIndexMock = $this->mockIndex(EmptyItem::class);
+        $emptyItemIndexMock->expects('clearObjects')->once();
+        $emptyItemIndexMock->expects('saveObjects')->once()->with([]);
 
         Artisan::call('scout:import');
     }

--- a/tests/Features/ImportCommandTest.php
+++ b/tests/Features/ImportCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Features;
 
+use App\EmptyItem;
 use Mockery;
 use App\News;
 use App\User;
@@ -45,6 +46,9 @@ final class ImportCommandTest extends TestCase
         // Detects searchable models.
         $threadIndexMock = $this->mockIndex(Thread::class);
         $threadIndexMock->expects('clearObjects')->once();
+
+        // Detects searchable models.
+        $this->mockIndex(EmptyItem::class)->expects('clearObjects')->once();
 
         Artisan::call('scout:import');
     }

--- a/tests/Features/ImportCommandTest.php
+++ b/tests/Features/ImportCommandTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Features;
 
-use App\EmptyItem;
 use Mockery;
 use App\News;
 use App\User;
 use App\Wall;
 use App\Thread;
+use App\EmptyItem;
 use function count;
 use Tests\TestCase;
 use Illuminate\Support\Facades\Artisan;

--- a/tests/Features/SearchableTest.php
+++ b/tests/Features/SearchableTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Features;
 
-use App\EmptyItem;
 use Mockery;
 use App\User;
+use App\EmptyItem;
 use Tests\TestCase;
 use Illuminate\Support\Arr;
 use Algolia\ScoutExtended\Searchable\ModelsResolver;

--- a/tests/Features/SearchableTest.php
+++ b/tests/Features/SearchableTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Features;
 
+use App\EmptyItem;
 use Mockery;
 use App\User;
 use Tests\TestCase;
@@ -27,5 +28,20 @@ final class SearchableTest extends TestCase
         }));
 
         $user->searchable();
+    }
+
+    public function testSearchableWithEmptySearchableArray(): void
+    {
+        $item = new EmptyItem([
+            'id' => 1,
+            'title' => 'Example Title',
+        ]);
+
+        $item->pushSoftDeleteMetadata();
+
+        $itemsIndex = $this->mockIndex(EmptyItem::class);
+        $itemsIndex->expects('saveObjects')->once()->with([]);
+
+        $item->searchable();
     }
 }

--- a/tests/laravel/app/EmptyItem.php
+++ b/tests/laravel/app/EmptyItem.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Laravel\Scout\Searchable;
+
+final class EmptyItem extends Model
+{
+    use SoftDeletes, Searchable;
+
+    protected $fillable = [
+        'id',
+        'title',
+    ];
+
+    public function toSearchableArray()
+    {
+        return [];
+    }
+}

--- a/tests/laravel/app/EmptyItem.php
+++ b/tests/laravel/app/EmptyItem.php
@@ -2,9 +2,9 @@
 
 namespace App;
 
+use Laravel\Scout\Searchable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Laravel\Scout\Searchable;
 
 final class EmptyItem extends Model
 {

--- a/tests/laravel/database/factories/EmptyItemFactory.php
+++ b/tests/laravel/database/factories/EmptyItemFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use App\EmptyItem;
+use Faker\Generator as Faker;
+
+$factory->define(EmptyItem::class, function (Faker $faker) {
+    return [
+        'title' => $faker->word,
+    ];
+});

--- a/tests/laravel/database/migrations/2014_10_12_000003_create_empty_items_table.php
+++ b/tests/laravel/database/migrations/2014_10_12_000003_create_empty_items_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+final class CreateEmptyItemsTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('empty_items', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('empty_items');
+    }
+}


### PR DESCRIPTION
When looping through searchable models, skip any model that return searchable array as empty.

This will solve #192 