### PR TITLE
chore: improves test suite launch from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,5 +62,13 @@
     "config": {
         "sort-packages": true,
         "preferred-install": "dist"
+    },
+    "scripts": {
+        "phpstan:test": "phpstan analyse --ansi",
+        "phpunit:test": "phpunit --colors=always",
+        "test": [
+            "@phpstan:test",
+            "@phpunit:test"
+        ]
     }
 }


### PR DESCRIPTION
This pull request adds the possibility of launch the test suite using `composer test`.