### PR TITLE
Allow multiple, customized records per model

### DIFF
--- a/src/Jobs/UpdateJob.php
+++ b/src/Jobs/UpdateJob.php
@@ -13,22 +13,22 @@ declare(strict_types=1);
 
 namespace Algolia\ScoutExtended\Jobs;
 
-use ReflectionClass;
-use function in_array;
-use function is_array;
-use function get_class;
-use function is_string;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Illuminate\Support\Collection;
 use Algolia\AlgoliaSearch\SearchClient;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Algolia\ScoutExtended\Searchable\ModelsResolver;
 use Algolia\ScoutExtended\Contracts\SplitterContract;
+use Algolia\ScoutExtended\Searchable\ModelsResolver;
 use Algolia\ScoutExtended\Searchable\ObjectIdEncrypter;
 use Algolia\ScoutExtended\Transformers\ConvertDatesToTimestamps;
 use Algolia\ScoutExtended\Transformers\ConvertNumericStringsToNumbers;
+use function get_class;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use function in_array;
+use function is_array;
+use function is_string;
+use ReflectionClass;
 
 /**
  * @internal
@@ -132,7 +132,7 @@ final class UpdateJob
             }
 
             if ($hasToSearchableRecords || $this->shouldBeSplitted($searchable)) {
-                if (!$hasToSearchableRecords) {
+                if (! $hasToSearchableRecords) {
                     $objects = $this->splitSearchable($searchable, $objects[0]);
                 }
                 foreach ($objects as $part => $object) {

--- a/tests/Features/Fixtures/ThreadWithSearchableRecords.php
+++ b/tests/Features/Fixtures/ThreadWithSearchableRecords.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Features\Fixtures;
+
+use App\Thread;
+
+class ThreadWithSearchableRecords extends Thread
+{
+    protected $table = 'threads';
+
+    public function toSearchableRecords(): array
+    {
+        return [
+            array_merge($this->toArray(), [ '_i' => 2 ]),
+            array_merge($this->toArray(), [ '_i' => 4 ]),
+            array_merge($this->toArray(), [ '_i' => 8 ]),
+        ];
+    }
+}

--- a/tests/Features/Fixtures/ThreadWithSearchableRecords.php
+++ b/tests/Features/Fixtures/ThreadWithSearchableRecords.php
@@ -11,9 +11,9 @@ class ThreadWithSearchableRecords extends Thread
     public function toSearchableRecords(): array
     {
         return [
-            array_merge($this->toArray(), [ '_i' => 2 ]),
-            array_merge($this->toArray(), [ '_i' => 4 ]),
-            array_merge($this->toArray(), [ '_i' => 8 ]),
+            array_merge($this->toArray(), ['_i' => 2]),
+            array_merge($this->toArray(), ['_i' => 4]),
+            array_merge($this->toArray(), ['_i' => 8]),
         ];
     }
 }

--- a/tests/Features/SearchableRecordsTest.php
+++ b/tests/Features/SearchableRecordsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features;
+
+use Mockery;
+use function count;
+use Tests\TestCase;
+use Tests\Features\Fixtures\ThreadWithSearchableRecords;
+
+final class SearchableRecordsTest extends TestCase
+{
+    public function testMultipleRecords(): void
+    {
+        $index = $this->mockIndex(ThreadWithSearchableRecords::class);
+
+        $index->shouldReceive('saveObjects')->once()->with(Mockery::on(function ($argument) {
+            return count($argument) === 3 &&
+                $argument[0]['objectID'] === 'Tests\Features\Fixtures\ThreadWithSearchableRecords::1::0' &&
+                $argument[1]['objectID'] === 'Tests\Features\Fixtures\ThreadWithSearchableRecords::1::1' &&
+                $argument[2]['objectID'] === 'Tests\Features\Fixtures\ThreadWithSearchableRecords::1::2' &&
+                $argument[0]['body'] === 'Hello!' &&
+                $argument[1]['body'] === 'Hello!' &&
+                $argument[2]['body'] === 'Hello!' &&
+                $argument[0]['_i'] == 2 &&
+                $argument[1]['_i'] == 4 &&
+                $argument[2]['_i'] == 8;
+        }))->andReturn($this->mockResponse());
+
+        $index->shouldReceive('deleteBy')->with([
+            'tagFilters' => [
+                ['Tests\Features\Fixtures\ThreadWithSearchableRecords::1'],
+            ],
+        ]);
+
+        ThreadWithSearchableRecords::create(['body' => 'Hello!']);
+    }
+}

--- a/tests/Features/SearchableRecordsTest.php
+++ b/tests/Features/SearchableRecordsTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Features;
 
-use Mockery;
 use function count;
-use Tests\TestCase;
+use Mockery;
 use Tests\Features\Fixtures\ThreadWithSearchableRecords;
+use Tests\TestCase;
 
 final class SearchableRecordsTest extends TestCase
 {


### PR DESCRIPTION
Sometimes there are cases where multiple, customized search index records need to be created per model record. As far as I know, scout-extended only supports customizing attributes for a single search index record via the `toSearchableArray()` method, or morphing one or more of these attributes via the `split*()` methods.

This pull request adds support for defining a `toSearchableRecords()` function on the Eloquent model. This function should return an array of arrays, each array being a search index record for that model.

```php
    public function toSearchableRecords(): array
    {
        return [
            [
                'title' => $this->title . ' min',
                'temp' => $this->temp_min,
            ],
            [
                'title' => $this->title . ' max',
                'temp' => $this->temp_max,
            ],
        ];
    }
```

If the `toSearchableRecords()` method is defined, then the `toSearchableArray()` and `split*()` methods will not be used.