### PR TITLE
Ignore errors when requiring files for inspection

### DIFF
--- a/src/Helpers/SearchableFinder.php
+++ b/src/Helpers/SearchableFinder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Algolia\ScoutExtended\Helpers;
 
+use Error;
 use function in_array;
 use Illuminate\Support\Str;
 use Laravel\Scout\Searchable;
@@ -97,7 +98,11 @@ final class SearchableFinder
             $configFiles = Finder::create()->files()->name('*.php')->in($this->app->path());
 
             foreach ($configFiles->files() as $file) {
-                require_once $file;
+                try {
+                    require_once $file;
+                } catch (Error $e) {
+                    // The file could not be loaded due to an error. Continue.
+                }
             }
 
             self::$declaredClasses = get_declared_classes();

--- a/src/Helpers/SearchableFinder.php
+++ b/src/Helpers/SearchableFinder.php
@@ -37,6 +37,11 @@ final class SearchableFinder
     private $app;
 
     /**
+     * @var \Illuminate\Console\Command
+     */
+    private $command;
+
+    /**
      * SearchableModelsFinder constructor.
      *
      * @param \Illuminate\Contracts\Foundation\Application $app
@@ -56,6 +61,8 @@ final class SearchableFinder
      */
     public function fromCommand(Command $command): array
     {
+        $this->command = $command;
+
         $searchables = (array) $command->argument('searchable');
 
         if (empty($searchables) && empty($searchables = $this->find())) {
@@ -101,7 +108,9 @@ final class SearchableFinder
                 try {
                     require_once $file;
                 } catch (Error $e) {
-                    // The file could not be loaded due to an error. Continue.
+                    if (isset($this->command)) {
+                        $this->command->info("{$file} could not be inspected due to an error being thrown while loading it.");
+                    }
                 }
             }
 

--- a/src/Helpers/SearchableFinder.php
+++ b/src/Helpers/SearchableFinder.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
 namespace Algolia\ScoutExtended\Helpers;
 
 use Error;
-use function in_array;
-use Illuminate\Support\Str;
-use Laravel\Scout\Searchable;
 use Illuminate\Console\Command;
-use Symfony\Component\Finder\Finder;
+use Illuminate\Support\Str;
+use function in_array;
+use Laravel\Scout\Searchable;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Finder\Finder;
 
 /**
  * @internal

--- a/tests/Features/SearchableFinderTest.php
+++ b/tests/Features/SearchableFinderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Features;
+
+use Tests\TestCase;
+
+final class SearchableFinderTest extends TestCase
+{
+    public function testWhenThereIsAnUnresolvableClass(): void
+    {
+        // inject a file that cannot be resolved
+        $filePath = \base_path('app/UnresolvableClass.php');
+        \file_put_contents(
+            $filePath,
+            \file_get_contents(\base_path('app/UnresolvableClass.php.stub'))
+        );
+
+        $this->artisan('scout:sync')->expectsOutput("{$filePath} could not be inspected due to an error being thrown while loading it.");
+
+        // remove the file again
+        unlink($filePath);
+    }
+}

--- a/tests/Features/SearchableFinderTest.php
+++ b/tests/Features/SearchableFinderTest.php
@@ -18,8 +18,12 @@ final class SearchableFinderTest extends TestCase
         );
 
         $this->artisan('scout:sync')->expectsOutput("{$filePath} could not be inspected due to an error being thrown while loading it.");
+    }
 
-        // remove the file again
-        unlink($filePath);
+    public function tearDown(): void
+    {
+        \unlink(\base_path('app/UnresolvableClass.php'));
+
+        parent::tearDown();
     }
 }

--- a/tests/laravel/app/UnresolvableClass.php.stub
+++ b/tests/laravel/app/UnresolvableClass.php.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use FromPackage\SomeBaseClass;
+
+final class UnresolvableClass extends SomeBaseClass
+{
+    // emmpty
+}


### PR DESCRIPTION
Fixes #213 

I think this is the best approach. I've also considered creating a `E_USER_NOTICE` but Laravel still catches that as a full error.

In my opinion, no errors should be thrown and the code should just ignore the non-imported classes.

Alternatively, there are 2 (perhaps slightly better) approaches:

1. Log a warning to the log file
2. Keep track of files not imported and send them back to the command, and log them as warnings to the command line.

That last one sounds nice but involves quite a bit of passing through the collection of files; not really clean.