### PR TITLE
fix: illuminate/contracts dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-json": "*",
         "algolia/algoliasearch-client-php": "^2.5.1",
         "illuminate/console": "^6.0|^7.0|^8.0",
-        "illuminate/contracts": "^8.0",
+        "illuminate/contracts": "^6.0|^7.0|^8.0",
         "illuminate/database": "^6.0|^7.0|^8.0",
         "illuminate/filesystem": "^6.0|^7.0|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",


### PR DESCRIPTION
This fixes the `illuminate/contracts` version constraint.