### PR TITLE
feat(ci): add PHP 8.0 to test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,5 +79,5 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ['7.3', '7.4']
+              version: ['7.3', '7.4', '8.0']
               laravel: ['^6.0', '^7.0', '^8.0']


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no (?)  
| Related Issue     | 
| Need Doc update   | no


## Describe your change
This adds PHP 8 to the test matrix. I'm not sure CircleCI already published an image for it, so let's see if that's the case.

## What problem is this fixing?
This ensures compatibility of our package with PHP 8.
