### PR TITLE
fix: use correct Circle variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,8 @@ aliases:
       then
         composer test
       else
-        export CI_PROJ_USERNAME=$CIRCLE_PROJECT_USERNAME
-        export CI_PROJ_REPONAME=$CIRCLE_PROJECT_REPONAME
+        export CI_PROJ_USERNAME=$CIRCLE_PR_USERNAME
+        export CI_PROJ_REPONAME=$CIRCLE_PR_REPONAME
 
         eval $(./algolia-keys export) && composer test
       fi

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "fzaninotto/faker": "^1.8",
         "mockery/mockery": "^1.1",
         "nunomaduro/larastan": "^0.6",
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^4.9|^5.9|^6.6",
         "phpstan/phpstan": "^0.12.14",
         "phpunit/phpunit": "^8.0|^9.0",
         "laravel/legacy-factories": "^1.0"


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | #256 
| Need Doc update   | no


## Describe your change
This updates the CircleCI config, which used the [incorrect variables](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables). This caused the key dealer to fail, resulting in API key errors. See [this PR](https://github.com/algolia/scout-extended/pull/256#issuecomment-738640759) to see the error in action. 
