### PR TITLE
fix: use correct variables for API key dealer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,9 @@ aliases:
       then
         composer test
       else
-        export CI_PROJ_USERNAME=$CIRCLE_PR_USERNAME
-        export CI_PROJ_REPONAME=$CIRCLE_PR_REPONAME
+        export CI_PROJ_USERNAME=$CIRCLE_PROJECT_USERNAME
+        export CI_PROJ_REPONAME=$CIRCLE_PROJECT_REPONAME
+        export TRAVIS_REPO_SLUG="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
 
         eval $(./algolia-keys export) && composer test
       fi

--- a/src/Settings/LocalFactory.php
+++ b/src/Settings/LocalFactory.php
@@ -250,7 +250,7 @@ final class LocalFactory
     {
         $attributes = [];
 
-        if (in_array(Aggregator::class, class_parents($searchable), true)) {
+        if (in_array(Aggregator::class, (array) class_parents($searchable), true)) {
             foreach (($instance = new $searchable)->getModels() as $model) {
                 $attributes = array_merge($attributes, $this->getAttributes($model));
             }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #258 
| Need Doc update   | no


## Describe your change
This sets all the required environment variables for properly using the API key dealer.