### PR TITLE
ci: test php8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ aliases:
 
   - &install_dependencies
     name: Install Composer dependencies
-    command: COMPOSER_MEMORY_LIMIT=-1 composer require "illuminate/contracts=<<parameters.laravel>>" --dev --prefer-dist --no-interaction --no-suggest
+    command: COMPOSER_MEMORY_LIMIT=-1 composer require "illuminate/contracts=<<parameters.laravel>>" --dev --prefer-dist --no-interaction
 
   - &save_cache
     name: save Composer cache
@@ -79,5 +79,5 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ['7.3', '7.4']
+              version: ['7.3', '7.4', '8.0']
               laravel: ['^6.0', '^7.0', '^8.0']

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-dom": "Required to use the HTML Splitter."
     },
     "require-dev": {
-        "fzaninotto/faker": "^1.8",
+        "fakerphp/faker": "^1.13",
         "mockery/mockery": "^1.4",
         "nunomaduro/larastan": "^0.6",
         "orchestra/testbench": "^4.9|^5.9|^6.6",

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,12 @@
     },
     "require-dev": {
         "fzaninotto/faker": "^1.8",
-        "mockery/mockery": "^1.1",
+        "mockery/mockery": "^1.4",
         "nunomaduro/larastan": "^0.6",
         "orchestra/testbench": "^4.0|^5.0|^6.0",
         "phpstan/phpstan": "^0.12.14",
         "phpunit/phpunit": "^8.0|^9.0",
-        "laravel/legacy-factories": "^1.0"
+        "laravel/legacy-factories": "^1.1"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "ext-json": "*",
-        "algolia/algoliasearch-client-php": "^2.5.1",
+        "algolia/algoliasearch-client-php": "^2.7.3",
         "illuminate/console": "^6.0|^7.0|^8.0",
         "illuminate/contracts": "^6.0|^7.0|^8.0",
         "illuminate/database": "^6.0|^7.0|^8.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3|^8.0",
         "ext-json": "*",
         "algolia/algoliasearch-client-php": "^2.5.1",
         "illuminate/console": "^6.0|^7.0|^8.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "fzaninotto/faker": "^1.8",
         "mockery/mockery": "^1.4",
         "nunomaduro/larastan": "^0.6",
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^4.9|^5.9|^6.6",
         "phpstan/phpstan": "^0.12.14",
         "phpunit/phpunit": "^8.0|^9.0",
         "laravel/legacy-factories": "^1.1"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,28 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="false"
-         beStrictAboutOutputDuringTests="true"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
->
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" beStrictAboutTestsThatDoNotTestAnything="false" beStrictAboutOutputDuringTests="true" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" failOnRisky="true" failOnWarning="true" processIsolation="false" stopOnError="false" stopOnFailure="false" verbose="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no

## Describe your change
This PR tests the support for PHP8. Due to an issue in the CI for forked PRs, the workflow keeps failing due to incorrect credentials. This error should not occur in non-forked PRs
