### PR TITLE
[BUG] - empty whereIn array results in condition ignored

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,3 +12,6 @@ parameters:
         - '#Unsafe usage of new static#'
         - '#Method Algolia\\ScoutExtended\\Console\\Commands\\OptimizeCommand::handle\(\) has no return typehint specified.#'
         - '#Call to an undefined method Illuminate\\Support\\HigherOrderCollectionProxy::pushSoftDeleteMetadata\(\)#'
+        - '#Cannot call method withScoutMetadata\(\) on class-string\|object.#'
+        - '#Cannot call method getScoutKey\(\) on class-string\|object.#'
+        - '#Cannot call method toSearchableArray\(\) on class-string\|object.#'

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -102,9 +102,13 @@ final class Builder extends BaseBuilder
      */
     public function whereIn($field, array $values): self
     {
-        $wheres = array_map(function ($value) use ($field) {
-            return "$field={$this->transform($value)}";
-        }, array_values($values));
+        if(! empty($values)) {
+            $wheres = array_map(function ($value) use ($field) {
+                return "$field={$this->transform($value)}";
+            }, array_values($values));
+        } else {
+            $wheres = ['0 = 1'];
+        }
 
         $this->wheres[] = $wheres;
 

--- a/tests/Features/WhereQueriesTest.php
+++ b/tests/Features/WhereQueriesTest.php
@@ -89,6 +89,17 @@ final class WhereQueriesTest extends TestCase
         User::search('foo')->whereIn('id', [1, 2, 3, 4])->get();
     }
 
+    public function testWhereInEmptyArray(): void
+    {
+        $this->mockIndex(User::class)->shouldReceive('search')->once()->with('foo', [
+            'numericFilters' => [
+                ['0 = 1'],
+            ],
+        ])->andReturn(['hits' => []]);
+
+        User::search('foo')->whereIn('id', [])->get();
+    }
+
     public function testMultipleWheres(): void
     {
         $this->mockIndex(User::class)->shouldReceive('search')->once()->with('foo', [


### PR DESCRIPTION

| Q                 | A
| ----------------- | ----------
| Bug fix?          | Yes
| New feature?      | No
| BC breaks?        | no     
| Related Issue     | Fix #200 
| Need Doc update   | no


## Describe your change

This will add an empty condition to the whereIn method to make sure it'll add the condition only if the array is not empty. if it's empty it'll add a false condition to make sure the condition will stop ALL records from being returned.

## What problem is this fixing?

Originally passing an empty array to `whereIn` resulted in ignoring the entire condition, this results in unexpected search results where a user might see more results than they should.

For example

```
// Returns all records matching the query ignores the id condition
// it'll return all results matching the search query and ignores completely the whereIn condition
$query = App\Models\Areas\Area::search('santa')->whereIn('author_id', [])->get();
```

With this fix, it'll do exactly what Laravel does with its query builder where if the array is empty it'll append a false condition.

```
// Returns all records matching the query appends 0 = 1 similar to how laravel handles the whereIn with empty array
// https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Query/Grammars/Grammar.php#L271
$query = App\Models\Areas\Area::search('santa')->whereIn('id', [])->get();
```

added a corresponding test to make sure everything passes with this change.
