### PR TITLE
chore: add documentation for local test suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,17 @@ Contributions are welcome, and are accepted via pull requests. Please review the
 * Please remember that we follow [SemVer](http://semver.org/).
 
 We have [StyleCI](https://styleci.io/) setup to automatically fix any code style issues.
+
+
+## Tests
+The test suite calls Algolia servers to test the storage, updating, and search of records. 
+If you want to run your tests locally, the test suite needs the `ALGOLIA_APP_ID` and `ALGOLIA_SECRET` variables available in your environment to make these calls.
+
+You can set these variables by, for example, passing them when running the `composer test` command:
+
+```sh
+ALGOLIA_APP_ID="yourAppID" ALGOLIA_SECRET="yourAdminAPIKey" composer test
+```
+
+Please note that the tests add records and perform operations on your application. 
+Therefore, it's best to create a separate application with a [free Algolia plan](https://www.algolia.com/pricing/), to ensure the test suite doesn't alter your production data if there are naming collisions, and you don't go over your own plan's limits.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,3 +12,6 @@ parameters:
         - '#Unsafe usage of new static#'
         - '#Method Algolia\\ScoutExtended\\Console\\Commands\\OptimizeCommand::handle\(\) has no return typehint specified.#'
         - '#Call to an undefined method Illuminate\\Support\\HigherOrderCollectionProxy::pushSoftDeleteMetadata\(\)#'
+        - '#Cannot call method withScoutMetadata\(\) on class-string\|object.#'
+        - '#Cannot call method getScoutKey\(\) on class-string\|object.#'
+        - '#Cannot call method toSearchableArray\(\) on class-string\|object.#'


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #245 
| Need Doc update   | no


## Describe your change
This adds some documentation on running the unit tests locally to clarify the contribution process.

Edit: d1aba83 ensures that we temporarily ignore errors that PHPStan raises due to a bug. See [this PR comment](https://github.com/algolia/scout-extended/pull/265#issuecomment-783351989) for more details.