### PR TITLE
Add LocalSettingsRepositoryContract

### DIFF
--- a/src/Console/Commands/OptimizeCommand.php
+++ b/src/Console/Commands/OptimizeCommand.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Algolia\ScoutExtended\Console\Commands;
 
 use Algolia\ScoutExtended\Algolia;
+use Algolia\ScoutExtended\Contracts\LocalSettingsRepositoryContract;
 use Algolia\ScoutExtended\Exceptions\ModelNotFoundException;
 use Algolia\ScoutExtended\Helpers\SearchableFinder;
-use Algolia\ScoutExtended\Repositories\LocalSettingsRepository;
 use Algolia\ScoutExtended\Settings\Compiler;
 use Algolia\ScoutExtended\Settings\LocalFactory;
 use Illuminate\Console\Command;
@@ -41,7 +41,7 @@ final class OptimizeCommand extends Command
         LocalFactory $localFactory,
         Compiler $compiler,
         SearchableFinder $searchableFinder,
-        LocalSettingsRepository $localRepository
+        LocalSettingsRepositoryContract $localRepository
     ) {
         foreach ($searchableFinder->fromCommand($this) as $searchable) {
             $this->output->text('🔎 Optimizing search experience in: <info>['.$searchable.']</info>');

--- a/src/Console/Commands/SyncCommand.php
+++ b/src/Console/Commands/SyncCommand.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Algolia\ScoutExtended\Console\Commands;
 
 use Algolia\ScoutExtended\Algolia;
+use Algolia\ScoutExtended\Contracts\LocalSettingsRepositoryContract;
 use Algolia\ScoutExtended\Helpers\SearchableFinder;
-use Algolia\ScoutExtended\Repositories\LocalSettingsRepository;
 use Algolia\ScoutExtended\Settings\Status;
 use Algolia\ScoutExtended\Settings\Synchronizer;
 use Illuminate\Console\Command;
@@ -41,7 +41,7 @@ final class SyncCommand extends Command
         Algolia $algolia,
         Synchronizer $synchronizer,
         SearchableFinder $searchableFinder,
-        LocalSettingsRepository $localRepository
+        LocalSettingsRepositoryContract $localRepository
     ): void {
         foreach ($searchableFinder->fromCommand($this) as $searchable) {
             $this->output->text('🔎 Analysing settings from: <info>['.$searchable.']</info>');

--- a/src/Contracts/LocalSettingsRepositoryContract.php
+++ b/src/Contracts/LocalSettingsRepositoryContract.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Scout Extended.
+ *
+ * (c) Algolia Team <contact@algolia.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace Algolia\ScoutExtended\Contracts;
+
+use Algolia\AlgoliaSearch\SearchIndex;
+use Algolia\ScoutExtended\Settings\Settings;
+
+interface LocalSettingsRepositoryContract
+{
+    /**
+     * Checks if the given index settings exists.
+     *
+     * @param  \Algolia\AlgoliaSearch\SearchIndex $index
+     *
+     * @return bool
+     */
+    public function exists(SearchIndex $index): bool;
+
+    /**
+     * Get the settings path of the given index name.
+     *
+     * @param  \Algolia\AlgoliaSearch\SearchIndex $index
+     *
+     * @return string
+     */
+    public function getPath(SearchIndex $index): string;
+
+    /**
+     * Find the settings of the given Index.
+     *
+     * @param \Algolia\AlgoliaSearch\SearchIndex $index
+     *
+     * @return \Algolia\ScoutExtended\Settings\Settings
+     */
+    public function find(SearchIndex $index): Settings;
+}

--- a/src/Repositories/LocalSettingsRepository.php
+++ b/src/Repositories/LocalSettingsRepository.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Algolia\ScoutExtended\Repositories;
 
 use Algolia\AlgoliaSearch\SearchIndex;
+use Algolia\ScoutExtended\Contracts\LocalSettingsRepositoryContract;
 use Algolia\ScoutExtended\Settings\Settings;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
@@ -21,7 +22,7 @@ use Illuminate\Support\Str;
 /**
  * @internal
  */
-final class LocalSettingsRepository
+final class LocalSettingsRepository implements LocalSettingsRepositoryContract
 {
     /**
      * @var \Algolia\ScoutExtended\Repositories\RemoteSettingsRepository

--- a/src/ScoutExtendedServiceProvider.php
+++ b/src/ScoutExtendedServiceProvider.php
@@ -22,10 +22,12 @@ use Algolia\ScoutExtended\Console\Commands\OptimizeCommand;
 use Algolia\ScoutExtended\Console\Commands\ReImportCommand;
 use Algolia\ScoutExtended\Console\Commands\StatusCommand;
 use Algolia\ScoutExtended\Console\Commands\SyncCommand;
+use Algolia\ScoutExtended\Contracts\LocalSettingsRepositoryContract;
 use Algolia\ScoutExtended\Engines\AlgoliaEngine;
 use Algolia\ScoutExtended\Helpers\SearchableFinder;
 use Algolia\ScoutExtended\Jobs\UpdateJob;
 use Algolia\ScoutExtended\Managers\EngineManager;
+use Algolia\ScoutExtended\Repositories\LocalSettingsRepository;
 use Algolia\ScoutExtended\Searchable\AggregatorObserver;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Scout\ScoutServiceProvider;
@@ -94,6 +96,8 @@ final class ScoutExtendedServiceProvider extends ServiceProvider
         $this->app->bind(SearchableFinder::class, function () {
             return new SearchableFinder($this->app);
         });
+
+        $this->app->singleton(LocalSettingsRepositoryContract::class, LocalSettingsRepository::class);
     }
 
     /**

--- a/src/Settings/Status.php
+++ b/src/Settings/Status.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Algolia\ScoutExtended\Settings;
 
 use Algolia\AlgoliaSearch\SearchIndex;
-use Algolia\ScoutExtended\Repositories\LocalSettingsRepository;
+use Algolia\ScoutExtended\Contracts\LocalSettingsRepositoryContract;
 use Algolia\ScoutExtended\Repositories\UserDataRepository;
 use Illuminate\Support\Str;
 use LogicException;
@@ -35,7 +35,7 @@ final class Status
     private $userDataRepository;
 
     /**
-     * @var \Algolia\ScoutExtended\Repositories\LocalSettingsRepository
+     * @var \Algolia\ScoutExtended\Contracts\LocalSettingsRepositoryContract
      */
     private $localRepository;
 
@@ -64,7 +64,7 @@ final class Status
     /**
      * Status constructor.
      *
-     * @param \Algolia\ScoutExtended\Repositories\LocalSettingsRepository $localRepository
+     * @param \Algolia\ScoutExtended\Contracts\LocalSettingsRepositoryContract $localRepository
      * @param \Algolia\ScoutExtended\Settings\Encrypter $encrypter
      * @param \Algolia\ScoutExtended\Settings\Settings $remoteSettings
      * @param \Algolia\AlgoliaSearch\SearchIndex $index
@@ -72,7 +72,7 @@ final class Status
      * @return void
      */
     public function __construct(
-        LocalSettingsRepository $localRepository,
+        LocalSettingsRepositoryContract $localRepository,
         UserDataRepository $userDataRepository,
         Encrypter $encrypter,
         Settings $remoteSettings,

--- a/src/Settings/Synchronizer.php
+++ b/src/Settings/Synchronizer.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Algolia\ScoutExtended\Settings;
 
 use Algolia\AlgoliaSearch\SearchIndex;
-use Algolia\ScoutExtended\Repositories\LocalSettingsRepository;
+use Algolia\ScoutExtended\Contracts\LocalSettingsRepositoryContract;
 use Algolia\ScoutExtended\Repositories\RemoteSettingsRepository;
 use Algolia\ScoutExtended\Repositories\UserDataRepository;
 
@@ -34,7 +34,7 @@ class Synchronizer
     private $encrypter;
 
     /**
-     * @var \Algolia\ScoutExtended\Repositories\LocalSettingsRepository
+     * @var \Algolia\ScoutExtended\Contracts\LocalSettingsRepositoryContract
      */
     private $localRepository;
 
@@ -53,7 +53,7 @@ class Synchronizer
      *
      * @param \Algolia\ScoutExtended\Settings\Compiler $compiler
      * @param \Algolia\ScoutExtended\Settings\Encrypter $encrypter
-     * @param \Algolia\ScoutExtended\Repositories\LocalSettingsRepository $localRepository
+     * @param \Algolia\ScoutExtended\Contracts\LocalSettingsRepositoryContract $localRepository
      * @param \Algolia\ScoutExtended\Repositories\RemoteSettingsRepository $remoteRepository
      * @param \Algolia\ScoutExtended\Repositories\UserDataRepository $userDataRepository
      *
@@ -62,7 +62,7 @@ class Synchronizer
     public function __construct(
         Compiler $compiler,
         Encrypter $encrypter,
-        LocalSettingsRepository $localRepository,
+        LocalSettingsRepositoryContract $localRepository,
         RemoteSettingsRepository $remoteRepository,
         UserDataRepository $userDataRepository
     ) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #123
| Need Doc update   | not necessarily


## Describe your change

We're working on a multi-tenant app and would like more fine-grained control over how config is stored. Since `LocalSettingsRepository` is `final`, we're not able to extend it to modify (see #222 for a previous attempt to make it extendable).

I respect the decision to keep everything `final`, so instead I propose creating a contract for the `LocalSettingsRepository`, so package users may bind their own implementation to the IoC.

## What problem is this fixing?

Provides more control over local configuration storage, useful when dealing with multiple environments (see #123) or multi-tenant applications.