### PR TITLE
fix: register macros and commands during boot

### DIFF
--- a/src/ScoutExtendedServiceProvider.php
+++ b/src/ScoutExtendedServiceProvider.php
@@ -40,6 +40,8 @@ final class ScoutExtendedServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'algolia');
+        $this->registerCommands();
+        $this->registerMacros();
     }
 
     /**
@@ -50,8 +52,6 @@ final class ScoutExtendedServiceProvider extends ServiceProvider
         $this->app->register(ScoutServiceProvider::class);
 
         $this->registerBinds();
-        $this->registerCommands();
-        $this->registerMacros();
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no

## Describe your change
This moves the registration of our macros and commands to the `boot` method of our service provider, where they need to be [according to the Laravel documentation](https://laravel.com/docs/8.x/providers#the-boot-method). This fixes an issue that could occur where the commands from Scout took preference over the Scout Extended commands, even if we override them.
