### PR TITLE
chore: update Algolia API client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "ext-json": "*",
-        "algolia/algoliasearch-client-php": "^2.7.3",
+        "algolia/algoliasearch-client-php": "^3.0.0",
         "illuminate/console": "^6.0|^7.0|^8.0",
         "illuminate/contracts": "^6.0|^7.0|^8.0",
         "illuminate/database": "^6.0|^7.0|^8.0",


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     

## Describe your change
This PR uses the latest version of the PHP API client, which drops support for PHP < 7.2. The new release doesn't have any B-breaking changes.
