### PR TITLE
Add support for Laravel Scout 9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,4 +81,4 @@ workflows:
           matrix:
             parameters:
               version: ['7.3', '7.4', '8.0']
-              laravel: ['^8.0']
+              laravel: ['^6.0', '^7.0', '^8.0']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,5 +80,5 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ['7.3', '7.4', '8.0']
-              laravel: ['^6.0', '^7.0', '^8.0']
+              version: ['7.4', '8.0']
+              laravel: ['^8.0']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,5 +80,5 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ['7.4', '8.0']
+              version: ['7.3', '7.4', '8.0']
               laravel: ['^8.0']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.18.0](https://github.com/algolia/scout-extended/compare/v1.17.0...v1.18.0) - 2021-04-29
 ### Changed
 - Add support for laravel/scout v9.0 ([#278](https://github.com/algolia/scout-extended/pull/278))
+- Removed support for older versions of Laravel (6.0, 7.0)
 
 ## [1.17.0](https://github.com/algolia/scout-extended/compare/v1.16.0...v1.17.0) - 2021-04-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.18.0](https://github.com/algolia/scout-extended/compare/v1.17.0...v1.18.0) - 2021-04-29
 ### Changed
 - Add support for laravel/scout v9.0 ([#278](https://github.com/algolia/scout-extended/pull/278))
-- Removed support for older versions of Laravel (6.0, 7.0)
 
 ## [1.17.0](https://github.com/algolia/scout-extended/compare/v1.16.0...v1.17.0) - 2021-04-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.18.0](https://github.com/algolia/scout-extended/compare/v1.17.0...v1.18.0) - 2021-04-29
+### Changed
+- Add support for laravel/scout v9.0 ([#278](https://github.com/algolia/scout-extended/pull/278))
+
 ## [1.17.0](https://github.com/algolia/scout-extended/compare/v1.16.0...v1.17.0) - 2021-04-14
 ### Changed
 - Update the Algolia API client version ([#277](https://github.com/algolia/scout-extended/pull/277))

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/database": "^6.0|^7.0|^8.0",
         "illuminate/filesystem": "^6.0|^7.0|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
-        "laravel/scout": "^8.0",
+        "laravel/scout": "^8.0|^9.0",
         "riimu/kit-phpencoder": "^2.4"
     },
     "suggest": {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?     | no
| BC breaks?       | yes
| Need Doc update  | no


## Describe your change

Add support for laravel/scout 9.0
Drop support for older versions of Laravel (6.0, 7.0)

## What problem is this fixing?
With this change you can use laravel/scout ^9.0
