### PR TITLE
Remove command registration console requirement

### DIFF
--- a/src/ScoutExtendedServiceProvider.php
+++ b/src/ScoutExtendedServiceProvider.php
@@ -107,17 +107,15 @@ final class ScoutExtendedServiceProvider extends ServiceProvider
      */
     private function registerCommands(): void
     {
-        if ($this->app->runningInConsole()) {
-            $this->commands([
-                MakeAggregatorCommand::class,
-                ImportCommand::class,
-                FlushCommand::class,
-                OptimizeCommand::class,
-                ReImportCommand::class,
-                StatusCommand::class,
-                SyncCommand::class,
-            ]);
-        }
+        $this->commands([
+            MakeAggregatorCommand::class,
+            ImportCommand::class,
+            FlushCommand::class,
+            OptimizeCommand::class,
+            ReImportCommand::class,
+            StatusCommand::class,
+            SyncCommand::class,
+        ]);
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | N/A
| Need Doc update   | not likely


## Describe your change

Removed the conditional `if ($this->app->runningInConsole())` from the command registration. This allows for a Developer to utilize `Artisan::call()` in the edge cases where that is useful.

## What problem is this fixing?

There will be times when the console commands need to be run from a UI, such as via a button in an administration panel. Developers should take care to handle their own errors in these cases, but preventing them from doing this is limiting the usefulness of this package. This is especially true with newer tools like Laravel Vapor and Nova working in conjunction since you don't readily have access to a CLI environment.

If limitation of these commands is  actually desired and warranted, then it would probably be better to keep this change and add a condition checking for a `--force` flag if the app is not run from the console rather than preventing them from registering.
