### PR TITLE
[Bugfix] Allow toSearchableArray on Traits

### DIFF
--- a/tests/Features/Fixtures/ThreadSearchableTrait.php
+++ b/tests/Features/Fixtures/ThreadSearchableTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Features\Fixtures;
+
+trait ThreadSearchableTrait
+{
+    public function toSearchableArray()
+    {
+        return [
+            'something' => 99,
+        ];
+    }
+}

--- a/tests/Features/Fixtures/ThreadWithSearchableArrayOnTrait.php
+++ b/tests/Features/Fixtures/ThreadWithSearchableArrayOnTrait.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\Features\Fixtures;
+
+use App\Thread;
+
+class ThreadWithSearchableArrayOnTrait extends Thread
+{
+    use ThreadSearchableTrait;
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bugfix?          | yes
| New feature?      | no
| BC breaks?        | no
| Need Doc update   | no

## What problem is this fixing?

<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->

The `UpdateJob` class has a little trick that checks if the model has a `toSearchableArray` implementation, and if it doesn't, it will apply a generic transformation.

Given that every searchable model has to implement Laravel Scout's Searchable trait, the check logic had to be wrapped around that. A simple `method_exists` wouldn't cut it.

To solve this, this package was making sure that the definition of the method `toSearchableArray` was the actual model's class.

. . .

The problem with this implementation comes when you want to group behavior inside a trait (especially for big models).
At Studocu we usually do this, and it took us a while to notice that the method `toSearchableArray` inside our `DocumentSearchable` trait for the Document model was being wrapped with an extra transformer.

## Describe your change

<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->

To add support for custom Traits (or even class inheritance), I changed the way we check if the `toSearchableArray` method is defined.

**Instead of checking that the method's definition is in the Model class, we're now checking that the method's definition doesn't come from the Scout/Searchable trait.**