### PR TITLE
Implement builder helper for optional filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Add `whereOptional` helper to send optional filters
 
 ## [1.18.0](https://github.com/algolia/scout-extended/compare/v1.17.0...v1.18.0) - 2021-04-29
 ### Changed

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -13,12 +13,18 @@ declare(strict_types=1);
 
 namespace Algolia\ScoutExtended;
 
+use Illuminate\Support\Collection;
 use function func_num_args;
 use function is_callable;
 use Laravel\Scout\Builder as BaseBuilder;
 
 final class Builder extends BaseBuilder
 {
+    /**
+     * @var Collection
+     */
+    private $optionalFilters;
+
     /**
      * {@inheritdoc}
      *
@@ -27,6 +33,7 @@ final class Builder extends BaseBuilder
     public function __construct($model, $query, $callback = null, $softDelete = false)
     {
         parent::__construct($model, (string) $query, $callback, $softDelete);
+        $this->optionalFilters = collect();
     }
 
     /**
@@ -113,6 +120,22 @@ final class Builder extends BaseBuilder
         $this->wheres[] = $wheres;
 
         return $this;
+    }
+
+    /**
+     * Add an optional filter to the search parameters.
+     *
+     * @link https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/
+     *
+     * @param  string $field
+     * @param  mixed $value
+     *
+     * @return  $this
+     */
+    public function whereOptional($field, $value): self
+    {
+        $this->optionalFilters->push("$field:$value");
+        return $this->with(['optionalFilters' => $this->optionalFilters->join(',')]);
     }
 
     /**

--- a/tests/Features/BuilderTest.php
+++ b/tests/Features/BuilderTest.php
@@ -30,10 +30,16 @@ final class BuilderTest extends TestCase
     {
         $this->mockIndex(User::class)
             ->expects('search')
-            ->with('foo', Mockery::subset(['optionalFilters' => 'sub1.id:1,sub2.name:hello']))
+            ->with(
+                'foo',
+                Mockery::subset([
+                    'optionalFilters' => 'sub1.id:1,sub2.name:hello',
+                    'queryLanguages' => ['fr', 'nl'],
+                ]))
             ->andReturn(['hits' => []]);
 
         User::search('foo')
+            ->with(['queryLanguages' => ['fr', 'nl']])
             ->whereOptional('sub1.id', 1)
             ->whereOptional('sub2.name', 'hello')
             ->get();
@@ -43,14 +49,20 @@ final class BuilderTest extends TestCase
     {
         $this->mockIndex(User::class)
             ->expects('search')
-            ->with('foo', Mockery::subset(['optionalFilters' => 'price:100']))
+            ->with(
+                'foo',
+                Mockery::subset([
+                    'optionalFilters' => 'price:100',
+                    'queryLanguages' => ['fr', 'nl'],
+                ]))
             ->andReturn(['hits' => []]);
 
         User::search('foo')
             ->whereOptional('sub1.id', 1)
             ->whereOptional('sub2.name', 'hello')
             ->with([
-                'optionalFilters' => 'price:100'
+                'optionalFilters' => 'price:100',
+                'queryLanguages' => ['fr', 'nl'],
             ])
             ->get();
     }
@@ -59,12 +71,18 @@ final class BuilderTest extends TestCase
     {
         $this->mockIndex(User::class)
             ->expects('search')
-            ->with('foo', Mockery::subset(['optionalFilters' => 'sub1.id:1,sub2.name:hello']))
+            ->with(
+                'foo',
+                Mockery::subset([
+                    'optionalFilters' => 'sub1.id:1,sub2.name:hello',
+                    'queryLanguages' => ['fr', 'nl'],
+                ]))
             ->andReturn(['hits' => []]);
 
         User::search('foo')
             ->with([
-                'optionalFilters' => 'price:100'
+                'optionalFilters' => 'price:100',
+                'queryLanguages' => ['fr', 'nl'],
             ])
             ->whereOptional('sub1.id', 1)
             ->whereOptional('sub2.name', 'hello')

--- a/tests/Features/BuilderTest.php
+++ b/tests/Features/BuilderTest.php
@@ -26,6 +26,51 @@ final class BuilderTest extends TestCase
         User::search('foo')->with(['aroundRadius' => 1])->get();
     }
 
+    public function testWhereOptional(): void
+    {
+        $this->mockIndex(User::class)
+            ->expects('search')
+            ->with('foo', Mockery::subset(['optionalFilters' => 'sub1.id:1,sub2.name:hello']))
+            ->andReturn(['hits' => []]);
+
+        User::search('foo')
+            ->whereOptional('sub1.id', 1)
+            ->whereOptional('sub2.name', 'hello')
+            ->get();
+    }
+
+    public function testWhereOptionalAndWith(): void
+    {
+        $this->mockIndex(User::class)
+            ->expects('search')
+            ->with('foo', Mockery::subset(['optionalFilters' => 'price:100']))
+            ->andReturn(['hits' => []]);
+
+        User::search('foo')
+            ->whereOptional('sub1.id', 1)
+            ->whereOptional('sub2.name', 'hello')
+            ->with([
+                'optionalFilters' => 'price:100'
+            ])
+            ->get();
+    }
+
+    public function testWithAndWhereOptional(): void
+    {
+        $this->mockIndex(User::class)
+            ->expects('search')
+            ->with('foo', Mockery::subset(['optionalFilters' => 'sub1.id:1,sub2.name:hello']))
+            ->andReturn(['hits' => []]);
+
+        User::search('foo')
+            ->with([
+                'optionalFilters' => 'price:100'
+            ])
+            ->whereOptional('sub1.id', 1)
+            ->whereOptional('sub2.name', 'hello')
+            ->get();
+    }
+
     public function testAroundLatLng(): void
     {
         $this->mockIndex(User::class)->expects('search')->with('bar', Mockery::subset(['aroundLatLng' => '48.8566,2.3522']))->andReturn(['hits' => []]);


### PR DESCRIPTION
Adding optional filters to the query can now be done with the `whereOptional` builder helper. It is still also possible to use `with`.

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | no
| Need Doc update   | yes

## Describe your change

A new `whereOptional` builder helper is introduced to add optional filters to a search.

## What problem is this fixing?

Using the `with` helper to send optional parameters can be tedious when you have multiple of them - especially if they're conditional. With that Pull Request, it is now possible to use `whereOptional` for optional filters just like `where` can be used for filters. It also removes the necessity to build strings in the specific format Algolia expects, as it is done under the hood by the `whereOptional` implementation.

Here is an example:

```php
// Before

$optionalFilters = collect("email.provider:gmail");

if (!empty($city)) {
    $optionalFilters->push("city.code:{$city->code}");
}

if (!empty($job)) {
    $optionalFilters->push("job.title:{$job->title}");
}

User::search('killian')
    ->with([
        'optionalFilters' => $optionalFilters->join(',')
    ])
    ->get();

// After

User::search('killian')
    ->whereOptional('email.provider', 'gmail')
    ->when(!empty($city), fn ($query) => $query->whereOptional('city.name', $city->name))
    ->when(!empty($job), fn ($query) => $query->whereOptional('job.title', $job->title))
    ->get()
```

## Implementation choice

The order in which `with` and `whereOptional` are used matters. The last used will always erase the optional filters set by the other one (see unit tests). I think this is an acceptable pitfall as you should only use one or the other, but the implementation could be smarter and always override the optional filters with what's provided in `with`, for instance.
