### PR TITLE
fix: circumvent queue when using aggregators

### DIFF
--- a/src/Searchable/Aggregator.php
+++ b/src/Searchable/Aggregator.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
+use Laravel\Scout\Scout;
 use function in_array;
 use Laravel\Scout\Events\ModelsImported;
 use Laravel\Scout\Searchable;
@@ -250,6 +251,21 @@ abstract class Aggregator implements SearchableCountableContract
     public function newCollection(array $searchables = []): Collection
     {
         return new Collection($searchables);
+    }
+
+    /**
+     * Dispatch the job to make the given models unsearchable.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @return void
+     */
+    public function queueRemoveFromSearch($models)
+    {
+        if ($models->isEmpty()) {
+            return;
+        }
+
+        $models->first()->searchableUsing()->delete($models);
     }
 
     /**

--- a/src/Searchable/Aggregator.php
+++ b/src/Searchable/Aggregator.php
@@ -19,7 +19,6 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
-use Laravel\Scout\Scout;
 use function in_array;
 use Laravel\Scout\Events\ModelsImported;
 use Laravel\Scout\Searchable;


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #282 

## Describe your change
This PR adds a change to circumvent the queue when using aggregators.

## What problem is this fixing?
See #282 
