### PR TITLE
chore: use new CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,8 @@ jobs:
     steps:
       - checkout
 
-      - run: sudo apt update
-      - run: sudo docker-php-ext-install zip
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y php-zip
       - restore_cache: *restore_cache
       - run: *install_dependencies
       - save_cache: *save_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - checkout
 
       - run: sudo apt-get update
-      - run: sudo apt-get install -y php-zip php-sqlite3 php-mysql
+      - run: sudo apt-get install -y php<<parameters.version>>-zip php<<parameters.version>>-sqlite3
       - restore_cache: *restore_cache
       - run: *install_dependencies
       - save_cache: *save_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ executors:
         description: "PHP version tag"
         type: string
     docker:
-        - image: circleci/php:<<parameters.version>>
+        - image: cimg/php:<<parameters.version>>
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - checkout
 
       - run: sudo apt-get update
-      - run: sudo apt-get install -y php-zip php-sqlite3
+      - run: sudo apt-get install -y php-zip php-sqlite3 php-mysql
       - restore_cache: *restore_cache
       - run: *install_dependencies
       - save_cache: *save_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - checkout
 
       - run: sudo apt-get update
-      - run: sudo apt-get install -y php-zip
+      - run: sudo apt-get install -y php-zip php-sqlite3
       - restore_cache: *restore_cache
       - run: *install_dependencies
       - save_cache: *save_cache


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no

## Describe your change
This PR changes the Docker image used to run our tests. The current one in use will be deprecated by CircleCI.