### PR TITLE
Defer to model's way of limiting the model set

### DIFF
--- a/src/Searchable/Aggregator.php
+++ b/src/Searchable/Aggregator.php
@@ -186,8 +186,10 @@ abstract class Aggregator implements SearchableCountableContract
 
             $softDeletes =
                 in_array(SoftDeletes::class, class_uses_recursive($model)) && config('scout.soft_delete', false);
+            
+            $query = $instance->makeSearchableUsing();
 
-            $instance->newQuery()->when($softDeletes, function ($query) {
+            $query->when($softDeletes, function ($query) {
                 $query->withTrashed();
             })->orderBy($instance->getKeyName())->chunk(config('scout.chunk.searchable', 500), function ($models) {
                 $models = $models->map(function ($model) {


### PR DESCRIPTION
This will allow optimization per model

Avoid indexing models you don't want to be indexed anymore.

When the indexing process hits `shouldBeSearchable` it is already iterating through a lot of "probably" unnecessary models.

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | yes


## Describe your change

When using aggregators, this implelents `MakeAllSearchable` independently of how each model is implementing it.


## What problem is this fixing?

At the moment, this only looks for soft deletes in order to limit the set algolia needs to evaluate before indexing it.
With this change, the aggregator will look for a per model implementation of `MakeAllSearchableUsing` in order for add extra rules to limit the set Algolia need to iterate to index.

```php

class MyModel extends model;

use Searchable;

   public function makeAllSearchableUsing($query)
   {
        return $query->where('active', 1);
   }


```