### PR TITLE
chore: make class non-final

### DIFF
--- a/src/Searchable/ObjectIdEncrypter.php
+++ b/src/Searchable/ObjectIdEncrypter.php
@@ -20,7 +20,7 @@ use function get_class;
 /**
  * @internal
  */
-final class ObjectIdEncrypter
+class ObjectIdEncrypter
 {
     /**
      * Holds the metadata separator.


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #293 


## Describe your change
This removes the `final` keyword from the `ObjectEncrypter` class, so its behavior can be customized. Please note that we don't provide support when you decide to override this class.