### PR TITLE
fix: force sync reimport

### DIFF
--- a/src/Console/Commands/ReImportCommand.php
+++ b/src/Console/Commands/ReImportCommand.php
@@ -76,12 +76,18 @@ final class ReImportCommand extends Command
 
             tap($this->output)->progressAdvance()->text("Importing records to index <info>{$temporaryName}</info>");
 
+            // Force disable queueing to prevent race conditions in indexing with large number of records.
+            $useQueues = $config->get('scout.queue');
+            $config->set('scout.queue', false);
+
             try {
                 $config->set('scout.prefix', self::$prefix.'_'.$scoutPrefix);
                 $searchable::makeAllSearchable();
             } finally {
                 $config->set('scout.prefix', $scoutPrefix);
             }
+
+            $config->set('scout.queue', $useQueues);
 
             tap($this->output)->progressAdvance()
                 ->text("Replacing index <info>{$index->getIndexName()}</info> by index <info>{$temporaryName}</info>");


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     

## Describe your change
This force the queue to be disabled during a reimport. This allows us to reimport lots of records (1M+) without having to worry about race conditions (performing the `moveIndex` before all records have been imported).

We can disable the queue here as well because it's meant to improve performance during requests, but this script is never called during requests so we don't _have_ to queue the operations, especially since it can lead to issues when you have a big number of records.