### PR TITLE
Add `lazyMap` method to Algolia engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Implement `lazyMap` method ([#307](https://github.com/algolia/scout-extended/pull/307))
+
 ## [2.0.2](https://github.com/algolia/scout-extended/compare/v2.0.1...v2.0.2) - 2022-02-24
 ### Fixed
 - Fixed bug where queued aggregator deletes failed ([#287](https://github.com/algolia/scout-extended/pull/287))
-
 
 ## [2.0.1](https://github.com/algolia/scout-extended/compare/v2.0.0...v2.0.1) - 2022-01-31
 ### Fixed

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -94,6 +94,14 @@ class AlgoliaEngine extends BaseAlgoliaEngine
     /**
      * {@inheritdoc}
      */
+    public function lazyMap(Builder $builder, $results, $searchable)
+    {
+        return $this->map($builder, $results, $searchable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function flush($model)
     {
         $index = $this->algolia->initIndex($model->searchableAs());

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -18,6 +18,7 @@ use Algolia\ScoutExtended\Jobs\DeleteJob;
 use Algolia\ScoutExtended\Jobs\UpdateJob;
 use Algolia\ScoutExtended\Searchable\ModelsResolver;
 use Algolia\ScoutExtended\Searchable\ObjectIdEncrypter;
+use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use function is_array;
 use Laravel\Scout\Builder;
@@ -96,7 +97,7 @@ class AlgoliaEngine extends BaseAlgoliaEngine
      */
     public function lazyMap(Builder $builder, $results, $searchable)
     {
-        return $this->map($builder, $results, $searchable);
+        return LazyCollection::make($this->map($builder, $results, $searchable));
     }
 
     /**


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #298
| Need Doc update   | no

## Describe your change

Adds a `lazyMap` method to the Algolia engine to fix #298. This PR is a band-aid solution—it doesn't actually implement any 'lazy' functionality the way Scout does, `lazyMap` behaves exactly the same as `map` and just returns a lazy collection, but at least now `lazyMap` will _work_ instead of returning no results.

## What problem is this fixing?

See #298. `lazyMap` is not currently implemented, and because Scout Extended uses different result keys than Scout does, calling `lazyMap` when using Scout Extended always returns no results.

cc @DevinCodes 