### PR TITLE
Fix Aggregator Collection macros being overwritten when other models boot

### DIFF
--- a/src/Searchable/Aggregator.php
+++ b/src/Searchable/Aggregator.php
@@ -62,9 +62,7 @@ abstract class Aggregator implements SearchableCountableContract
      */
     public static function bootSearchable(): void
     {
-        ($self = new static)->registerSearchableMacros();
-
-        $observer = tap(app(AggregatorObserver::class))->setAggregator(static::class, $models = $self->getModels());
+        $observer = tap(app(AggregatorObserver::class))->setAggregator(static::class, $models = (new static)->getModels());
 
         foreach ($models as $model) {
             $model::observe($observer);

--- a/src/Searchable/AggregatorCollection.php
+++ b/src/Searchable/AggregatorCollection.php
@@ -20,7 +20,6 @@ use Illuminate\Support\Collection;
 
 /**
  * @method static string searchable()
- * @method static string unsearchable()
  */
 final class AggregatorCollection extends Collection
 {
@@ -32,6 +31,18 @@ final class AggregatorCollection extends Collection
      * @var string|null
      */
     public $aggregator;
+
+    /**
+     * Make all the models in this collection unsearchable.
+     *
+     * @return void
+     */
+    public function unsearchable(): void
+    {
+        $aggregator = get_class($this->first());
+
+        (new $aggregator)->queueRemoveFromSearch($this);
+    }
 
     /**
      * Prepare the instance for serialization.

--- a/src/Searchable/AggregatorCollection.php
+++ b/src/Searchable/AggregatorCollection.php
@@ -19,7 +19,7 @@ use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 use Illuminate\Support\Collection;
 
 /**
- * @method static string searchable()
+ * @method static void searchable()
  */
 final class AggregatorCollection extends Collection
 {

--- a/tests/Features/AggregatorTest.php
+++ b/tests/Features/AggregatorTest.php
@@ -287,9 +287,10 @@ final class AggregatorTest extends TestCase
 
         // Because the Thread model had not been booted yet, booting `All` above caused it to
         // boot, which in turn booted its Searchable trait and re-registered Scout's base
-        // Collection macros, overriding the aggregator. Calling `unsearchable` on an
-        // Aggregator will now incorrectly end up calling `queueRemoveFromSearch`
-        // on the Thread model, dispatching the job above.
+        // Collection macros, overriding the aggregator.
+
+        // Calling `unsearchable` on an Aggregator should bypass these macros and still end
+        // up calling `queueRemoveFromSearch` on the Aggregator, not dispatching any jobs.
 
         $user->delete();
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fix #305
| Need Doc update   | no

## Describe your change

This PR adds an `unsearchable` method to Scout Extended's `AggregatorCollection` class. This ensures that any time an Aggregator is removed from search, it gets removed using the `queueRemoveFromSearch` method on itself or on the base `Aggregator` class it extends, _never_ the method in Scout's base `Searchable` trait.

The issue is demonstrated with a failing test in the first commit, the fix is included in the second commit and that test should then pass.

I also removed the manual re-registration of the Collection macros in the aggregator, since it's now unnecessary—for `searchable`, Scout Extended's behaviour is the same as Scout's, and for `unsearchable`, Scout Extended now doesn't use a macro at all.

## What problem is this fixing?

Any time any Searchable Eloquent model boots, it registers Scout's base `searchable` and `unsearchable` Collection macros. Scout Extended's Aggregators also register these same macros, overriding Scout's, specifically to avoid queuing the removal of deleted models. If any Searchable model boots _after_ an Aggregator`, Scout's macros will be re-registered, overriding Scout Extended's. Fixes #305.

cc @DevinCodes 