### PR TITLE
fix: register macros

### DIFF
--- a/src/Searchable/Aggregator.php
+++ b/src/Searchable/Aggregator.php
@@ -62,6 +62,7 @@ abstract class Aggregator implements SearchableCountableContract
      */
     public static function bootSearchable(): void
     {
+        ($self = new static)->registerSearchableMacros(); 
         $observer = tap(app(AggregatorObserver::class))->setAggregator(static::class, $models = (new static)->getModels());
 
         foreach ($models as $model) {


### PR DESCRIPTION
This fixes a bug introduced in the last release where macros for Aggregators were not registered, which causes issues when models in the aggregator don't have the `Searchable` trait.