### PR TITLE
Remove final keyword from AggregatorObserver class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Remove `final` keyword from `Algolia\ScoutExtended\Searchable\AggregatorObserver` ([#312](https://github.com/algolia/scout-extended/pull/312))
 
 ## [2.0.4](https://github.com/algolia/scout-extended/compare/v2.0.3...v2.0.4) - 2022-06-20
 ### Fixed

--- a/src/Searchable/AggregatorObserver.php
+++ b/src/Searchable/AggregatorObserver.php
@@ -16,7 +16,7 @@ namespace Algolia\ScoutExtended\Searchable;
 use function get_class;
 use Laravel\Scout\ModelObserver as BaseModelObserver;
 
-final class AggregatorObserver extends BaseModelObserver
+class AggregatorObserver extends BaseModelObserver
 {
     /**
      * @var array [


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change

Maybe you would consider this a new feature, perhaps not?

Remove `final` keyword from `Algolia\ScoutExtended\Searchable\AggregatorObserver`, allowing extension and modification.

## What problem is this fixing?

Currently, I have a use case where I want to update the logic of the event handler methods (`saved`, `deleted`, `forceDeleted`). I am able to build a new, customized ModelObserver class that extends this package's ModelObserver class which is nice and expected. 

Unfortunately, and for reasons that are not abundantly clear, the package's `AggregatorObserver` class is decorated with the final keyword which means updating the behavior would require reimplementing the entire class, instead of simply extending and modifying only where needed. 

Specifically there is one line of code in the default `saved` where this is problematic:

https://github.com/algolia/scout-extended/blob/625276ab9ff5b11a22942a5d41063186bcbfaeec/src/Searchable/AggregatorObserver.php#L70-L81

This line of code invokes the parent ModelObserver (which is the default ModelObserver from the package) and there is no way to intercept this invocation to direct the call to a custom ModelObserver. 

https://github.com/algolia/scout-extended/blob/625276ab9ff5b11a22942a5d41063186bcbfaeec/src/Searchable/AggregatorObserver.php#L15-L20

Having the ability to replace the implementation registered in the service container with a new AggregatorObserver that extends the package's default AggregatorObserver would be a real nice lift here.

```php
$this->app->singleton(AggregatorObserver::class, MyCustomAggregatorObserver::class);
```

Please consider one of the two outcomes here:

1. Let's work together to get this change safely merged
2. Explain why it is important for the `Algolia\ScoutExtended\Searchable\AggregatorObserver` class to be final

There is a possibility that this change will unblock https://github.com/algolia/scout-extended/pull/301 as well - downstream implementations could update the proposed logic in that PR on their own.