### PR TITLE
Add replica indices to the secured api search key

### DIFF
--- a/src/Repositories/ApiKeysRepository.php
+++ b/src/Repositories/ApiKeysRepository.php
@@ -85,11 +85,13 @@ final class ApiKeysRepository
             // Key will be valid for 25 hours.
             $validUntil = time() + (3600 * 25);
 
+            $replicas = config('scout-'.str_replace('_', '-', $searchableAs).'.replicas', []);
+            $restrictIndices = join(',', [$searchableAs, ...$replicas]);
+
             $securedSearchKey = $this->client::generateSecuredApiKey($searchKey, [
-                'restrictIndices' => $searchableAs,
+                'restrictIndices' => $restrictIndices,
                 'validUntil' => $validUntil,
             ]);
-
             $this->cache->put(
                 self::SEARCH_KEY.'.'.$searchableAs, $securedSearchKey, DateInterval::createFromDateString('24 hours')
             );


### PR DESCRIPTION
The api key generated via `Algolia::searchKey` is too restrictive, it only includes the primary index in its `restrictIndices` array. When using replicas for sorting with that key it fails, because the replicas are not included. This happens when sending the (secured) search key to a frontend javascript that only has one api key.

This change loads the `replicas` setting from the associated index config file and appends that to the `restrictIndices`.

There is probably a better way to load the config, I didn't dive that deep in the code. Perhaps it should be loaded from the remote index instead of via the local synced config file?