### PR TITLE
chore: remove `final` keyword from classes

### DIFF
--- a/src/Algolia.php
+++ b/src/Algolia.php
@@ -20,7 +20,7 @@ use Algolia\ScoutExtended\Repositories\ApiKeysRepository;
 use Illuminate\Contracts\Container\Container;
 use function is_string;
 
-final class Algolia
+class Algolia
 {
     /**
      * @var \Illuminate\Contracts\Container\Container

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -18,7 +18,7 @@ use function func_num_args;
 use function is_callable;
 use Laravel\Scout\Builder as BaseBuilder;
 
-final class Builder extends BaseBuilder
+class Builder extends BaseBuilder
 {
     /**
      * @var Collection

--- a/src/Console/Commands/FlushCommand.php
+++ b/src/Console/Commands/FlushCommand.php
@@ -17,7 +17,7 @@ use Algolia\ScoutExtended\Algolia;
 use Algolia\ScoutExtended\Helpers\SearchableFinder;
 use Illuminate\Console\Command;
 
-final class FlushCommand extends Command
+class FlushCommand extends Command
 {
     /**
      * {@inheritdoc}

--- a/src/Console/Commands/ImportCommand.php
+++ b/src/Console/Commands/ImportCommand.php
@@ -20,7 +20,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Collection;
 use Laravel\Scout\Events\ModelsImported;
 
-final class ImportCommand extends Command
+class ImportCommand extends Command
 {
     /**
      * {@inheritdoc}

--- a/src/Console/Commands/MakeAggregatorCommand.php
+++ b/src/Console/Commands/MakeAggregatorCommand.php
@@ -15,7 +15,7 @@ namespace Algolia\ScoutExtended\Console\Commands;
 
 use Illuminate\Console\GeneratorCommand;
 
-final class MakeAggregatorCommand extends GeneratorCommand
+class MakeAggregatorCommand extends GeneratorCommand
 {
     /**
      * {@inheritdoc}

--- a/src/Console/Commands/OptimizeCommand.php
+++ b/src/Console/Commands/OptimizeCommand.php
@@ -21,7 +21,7 @@ use Algolia\ScoutExtended\Settings\Compiler;
 use Algolia\ScoutExtended\Settings\LocalFactory;
 use Illuminate\Console\Command;
 
-final class OptimizeCommand extends Command
+class OptimizeCommand extends Command
 {
     /**
      * {@inheritdoc}

--- a/src/Console/Commands/ReImportCommand.php
+++ b/src/Console/Commands/ReImportCommand.php
@@ -20,7 +20,7 @@ use Algolia\ScoutExtended\Helpers\SearchableFinder;
 use function count;
 use Illuminate\Console\Command;
 
-final class ReImportCommand extends Command
+class ReImportCommand extends Command
 {
     /**
      * {@inheritdoc}

--- a/src/Console/Commands/StatusCommand.php
+++ b/src/Console/Commands/StatusCommand.php
@@ -20,7 +20,7 @@ use Algolia\ScoutExtended\Settings\Synchronizer;
 use function count;
 use Illuminate\Console\Command;
 
-final class StatusCommand extends Command
+class StatusCommand extends Command
 {
     /**
      * {@inheritdoc}

--- a/src/Console/Commands/SyncCommand.php
+++ b/src/Console/Commands/SyncCommand.php
@@ -20,7 +20,7 @@ use Algolia\ScoutExtended\Settings\Status;
 use Algolia\ScoutExtended\Settings\Synchronizer;
 use Illuminate\Console\Command;
 
-final class SyncCommand extends Command
+class SyncCommand extends Command
 {
     /**
      * {@inheritdoc}

--- a/src/Exceptions/ModelNotDefinedInAggregatorException.php
+++ b/src/Exceptions/ModelNotDefinedInAggregatorException.php
@@ -16,7 +16,7 @@ namespace Algolia\ScoutExtended\Exceptions;
 use RuntimeException;
 use Throwable;
 
-final class ModelNotDefinedInAggregatorException extends RuntimeException
+class ModelNotDefinedInAggregatorException extends RuntimeException
 {
     /**
      * {@inheritdoc}

--- a/src/Exceptions/ModelNotFoundException.php
+++ b/src/Exceptions/ModelNotFoundException.php
@@ -18,7 +18,7 @@ use RuntimeException;
 /**
  * @internal
  */
-final class ModelNotFoundException extends RuntimeException
+class ModelNotFoundException extends RuntimeException
 {
     /**
      * Name of the affected model.

--- a/src/Exceptions/SettingsNotFound.php
+++ b/src/Exceptions/SettingsNotFound.php
@@ -16,7 +16,7 @@ namespace Algolia\ScoutExtended\Exceptions;
 use Exception;
 use Throwable;
 
-final class SettingsNotFound extends Exception
+class SettingsNotFound extends Exception
 {
     /**
      * {@inheritdoc}

--- a/src/Exceptions/ShouldReimportSearchableException.php
+++ b/src/Exceptions/ShouldReimportSearchableException.php
@@ -15,6 +15,6 @@ namespace Algolia\ScoutExtended\Exceptions;
 
 use RuntimeException;
 
-final class ShouldReimportSearchableException extends RuntimeException
+class ShouldReimportSearchableException extends RuntimeException
 {
 }

--- a/src/Facades/Algolia.php
+++ b/src/Facades/Algolia.php
@@ -23,7 +23,7 @@ use Illuminate\Support\Facades\Facade;
  *
  * @see \Algolia\ScoutExtended\Algolia
  */
-final class Algolia extends Facade
+class Algolia extends Facade
 {
     /**
      * {@inheritdoc}

--- a/src/Helpers/SearchableFinder.php
+++ b/src/Helpers/SearchableFinder.php
@@ -26,7 +26,7 @@ use function in_array;
 /**
  * @internal
  */
-final class SearchableFinder
+class SearchableFinder
 {
     /**
      * @var array

--- a/src/Jobs/DeleteJob.php
+++ b/src/Jobs/DeleteJob.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Collection;
 /**
  * @internal
  */
-final class DeleteJob
+class DeleteJob
 {
     /**
      * @var \Illuminate\Support\Collection

--- a/src/Jobs/UpdateJob.php
+++ b/src/Jobs/UpdateJob.php
@@ -34,7 +34,7 @@ use ReflectionClass;
 /**
  * @internal
  */
-final class UpdateJob
+class UpdateJob
 {
     /**
      * Contains a list of splittables searchables.

--- a/src/Repositories/ApiKeysRepository.php
+++ b/src/Repositories/ApiKeysRepository.php
@@ -21,7 +21,7 @@ use function is_string;
 /**
  * @internal
  */
-final class ApiKeysRepository
+class ApiKeysRepository
 {
     /**
      * Holds the search key.

--- a/src/Repositories/LocalSettingsRepository.php
+++ b/src/Repositories/LocalSettingsRepository.php
@@ -22,7 +22,7 @@ use Illuminate\Support\Str;
 /**
  * @internal
  */
-final class LocalSettingsRepository implements LocalSettingsRepositoryContract
+class LocalSettingsRepository implements LocalSettingsRepositoryContract
 {
     /**
      * @var \Algolia\ScoutExtended\Repositories\RemoteSettingsRepository

--- a/src/Repositories/RemoteSettingsRepository.php
+++ b/src/Repositories/RemoteSettingsRepository.php
@@ -21,7 +21,7 @@ use Algolia\ScoutExtended\Settings\Settings;
 /**
  * @internal
  */
-final class RemoteSettingsRepository
+class RemoteSettingsRepository
 {
     /**
      * Settings that may be know by other names.

--- a/src/Repositories/UserDataRepository.php
+++ b/src/Repositories/UserDataRepository.php
@@ -18,7 +18,7 @@ use Algolia\AlgoliaSearch\SearchIndex;
 /**
  * @internal
  */
-final class UserDataRepository
+class UserDataRepository
 {
     /**
      * @var \Algolia\ScoutExtended\Repositories\RemoteSettingsRepository

--- a/src/ScoutExtendedServiceProvider.php
+++ b/src/ScoutExtendedServiceProvider.php
@@ -32,7 +32,7 @@ use Algolia\ScoutExtended\Searchable\AggregatorObserver;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Scout\ScoutServiceProvider;
 
-final class ScoutExtendedServiceProvider extends ServiceProvider
+class ScoutExtendedServiceProvider extends ServiceProvider
 {
     /**
      * {@inheritdoc}

--- a/src/Searchable/AggregatorCollection.php
+++ b/src/Searchable/AggregatorCollection.php
@@ -21,7 +21,7 @@ use Illuminate\Support\Collection;
 /**
  * @method static void searchable()
  */
-final class AggregatorCollection extends Collection
+class AggregatorCollection extends Collection
 {
     use SerializesAndRestoresModelIdentifiers;
 

--- a/src/Searchable/AggregatorObserver.php
+++ b/src/Searchable/AggregatorObserver.php
@@ -16,7 +16,7 @@ namespace Algolia\ScoutExtended\Searchable;
 use function get_class;
 use Laravel\Scout\ModelObserver as BaseModelObserver;
 
-final class AggregatorObserver extends BaseModelObserver
+class AggregatorObserver extends BaseModelObserver
 {
     /**
      * @var array [

--- a/src/Searchable/ModelsResolver.php
+++ b/src/Searchable/ModelsResolver.php
@@ -24,7 +24,7 @@ use Laravel\Scout\Searchable;
 /**
  * @internal
  */
-final class ModelsResolver
+class ModelsResolver
 {
     /**
      * @var string[]

--- a/src/Searchable/RecordsCounter.php
+++ b/src/Searchable/RecordsCounter.php
@@ -20,7 +20,7 @@ use function in_array;
 /**
  * @internal
  */
-final class RecordsCounter
+class RecordsCounter
 {
     /**
      * Get the number of local searchable records of

--- a/src/Settings/Compiler.php
+++ b/src/Settings/Compiler.php
@@ -21,7 +21,7 @@ use Riimu\Kit\PHPEncoder\PHPEncoder;
 /**
  * @internal
  */
-final class Compiler
+class Compiler
 {
     /**
      * Array of opening and closing tags for raw echos.

--- a/src/Settings/Encrypter.php
+++ b/src/Settings/Encrypter.php
@@ -16,7 +16,7 @@ namespace Algolia\ScoutExtended\Settings;
 /**
  * @internal
  */
-final class Encrypter
+class Encrypter
 {
     /**
      * @param  \Algolia\ScoutExtended\Settings\Settings $settings

--- a/src/Settings/LocalFactory.php
+++ b/src/Settings/LocalFactory.php
@@ -26,7 +26,7 @@ use function is_string;
 /**
  * @internal
  */
-final class LocalFactory
+class LocalFactory
 {
     /**
      * @var \Algolia\ScoutExtended\Repositories\RemoteSettingsRepository

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -18,7 +18,7 @@ use function in_array;
 /**
  * @internal
  */
-final class Settings
+class Settings
 {
     /**
      * @var array

--- a/src/Settings/Status.php
+++ b/src/Settings/Status.php
@@ -22,7 +22,7 @@ use LogicException;
 /**
  * @internal
  */
-final class Status
+class Status
 {
     /**
      * @var \Algolia\ScoutExtended\Settings\Encrypter

--- a/src/Transformers/ConvertDatesToTimestamps.php
+++ b/src/Transformers/ConvertDatesToTimestamps.php
@@ -15,7 +15,7 @@ namespace Algolia\ScoutExtended\Transformers;
 
 use Algolia\ScoutExtended\Contracts\TransformerContract;
 
-final class ConvertDatesToTimestamps implements TransformerContract
+class ConvertDatesToTimestamps implements TransformerContract
 {
     /**
      * Converts the given array numeric strings to numbers.

--- a/src/Transformers/ConvertNumericStringsToNumbers.php
+++ b/src/Transformers/ConvertNumericStringsToNumbers.php
@@ -16,7 +16,7 @@ namespace Algolia\ScoutExtended\Transformers;
 use Algolia\ScoutExtended\Contracts\TransformerContract;
 use function is_string;
 
-final class ConvertNumericStringsToNumbers implements TransformerContract
+class ConvertNumericStringsToNumbers implements TransformerContract
 {
     /**
      * Converts the given array numeric strings to numbers.

--- a/tests/Features/AggregatorTest.php
+++ b/tests/Features/AggregatorTest.php
@@ -18,7 +18,7 @@ use Mockery;
 use RuntimeException;
 use Tests\TestCase;
 
-final class AggregatorTest extends TestCase
+class AggregatorTest extends TestCase
 {
     public function testWhenAggregagorIsNotBooted(): void
     {

--- a/tests/Features/AlgoliaTest.php
+++ b/tests/Features/AlgoliaTest.php
@@ -11,7 +11,7 @@ use Algolia\ScoutExtended\Algolia;
 use App\User;
 use Tests\TestCase;
 
-final class AlgoliaTest extends TestCase
+class AlgoliaTest extends TestCase
 {
     public $algolia;
 

--- a/tests/Features/BuilderTest.php
+++ b/tests/Features/BuilderTest.php
@@ -8,7 +8,7 @@ use App\User;
 use Mockery;
 use Tests\TestCase;
 
-final class BuilderTest extends TestCase
+class BuilderTest extends TestCase
 {
     public function testCount(): void
     {

--- a/tests/Features/FacadeTest.php
+++ b/tests/Features/FacadeTest.php
@@ -8,7 +8,7 @@ use Algolia\ScoutExtended\Algolia;
 use Algolia\ScoutExtended\Facades\Algolia as AlgoliaFacade;
 use Tests\TestCase;
 
-final class FacadeTest extends TestCase
+class FacadeTest extends TestCase
 {
     public function testFacadeResolvedService(): void
     {

--- a/tests/Features/FlushCommandTest.php
+++ b/tests/Features/FlushCommandTest.php
@@ -13,7 +13,7 @@ use App\Wall;
 use Modules\Taxonomy\Term;
 use Tests\TestCase;
 
-final class FlushCommandTest extends TestCase
+class FlushCommandTest extends TestCase
 {
     public function testClearsIndex(): void
     {

--- a/tests/Features/ImportCommandTest.php
+++ b/tests/Features/ImportCommandTest.php
@@ -16,7 +16,7 @@ use Mockery;
 use Modules\Taxonomy\Term;
 use Tests\TestCase;
 
-final class ImportCommandTest extends TestCase
+class ImportCommandTest extends TestCase
 {
     public function testImport(): void
     {

--- a/tests/Features/MakeAggregatorCommandTest.php
+++ b/tests/Features/MakeAggregatorCommandTest.php
@@ -7,7 +7,7 @@ namespace Tests\Features;
 use Illuminate\Support\Facades\Artisan;
 use Tests\TestCase;
 
-final class MakeAggregatorCommandTest extends TestCase
+class MakeAggregatorCommandTest extends TestCase
 {
     public function setUp(): void
     {

--- a/tests/Features/OptimizeCommandTest.php
+++ b/tests/Features/OptimizeCommandTest.php
@@ -8,7 +8,7 @@ use App\User;
 use Illuminate\Support\Facades\Artisan;
 use Tests\TestCase;
 
-final class OptimizeCommandTest extends TestCase
+class OptimizeCommandTest extends TestCase
 {
     public function testCreationOfLocalSettings(): void
     {

--- a/tests/Features/PaginateTest.php
+++ b/tests/Features/PaginateTest.php
@@ -7,7 +7,7 @@ namespace Tests\Features;
 use App\User;
 use Tests\TestCase;
 
-final class PaginateTest extends TestCase
+class PaginateTest extends TestCase
 {
     public function setUp(): void
     {

--- a/tests/Features/ReimportCommandTest.php
+++ b/tests/Features/ReimportCommandTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Artisan;
 use Mockery;
 use Tests\TestCase;
 
-final class ReimportCommandTest extends TestCase
+class ReimportCommandTest extends TestCase
 {
     public function testReimport(): void
     {

--- a/tests/Features/SearchKeyTest.php
+++ b/tests/Features/SearchKeyTest.php
@@ -9,7 +9,7 @@ use App\User;
 use App\Wall;
 use Tests\TestCase;
 
-final class SearchKeyTest extends TestCase
+class SearchKeyTest extends TestCase
 {
     public function testWhenSearchApiDontExists(): void
     {

--- a/tests/Features/SearchTest.php
+++ b/tests/Features/SearchTest.php
@@ -9,7 +9,7 @@ use App\Thread;
 use App\User;
 use Tests\TestCase;
 
-final class SearchTest extends TestCase
+class SearchTest extends TestCase
 {
     public function testSearchEmpty(): void
     {

--- a/tests/Features/SearchableFinderTest.php
+++ b/tests/Features/SearchableFinderTest.php
@@ -11,7 +11,7 @@ use function file_get_contents;
 use function file_put_contents;
 use function unlink;
 
-final class SearchableFinderTest extends TestCase
+class SearchableFinderTest extends TestCase
 {
     public function testWhenThereIsAnUnresolvableClass(): void
     {

--- a/tests/Features/SearchableTest.php
+++ b/tests/Features/SearchableTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Arr;
 use Mockery;
 use Tests\TestCase;
 
-final class SearchableTest extends TestCase
+class SearchableTest extends TestCase
 {
     public function testSearchable(): void
     {

--- a/tests/Features/SplittersTest.php
+++ b/tests/Features/SplittersTest.php
@@ -12,7 +12,7 @@ use Tests\Features\Fixtures\ThreadWithSplitterInstance;
 use Tests\Features\Fixtures\ThreadWithValueReturned;
 use Tests\TestCase;
 
-final class SplittersTest extends TestCase
+class SplittersTest extends TestCase
 {
     public function testRecordsAreSplittedByASplitter(): void
     {

--- a/tests/Features/StatusCommandTest.php
+++ b/tests/Features/StatusCommandTest.php
@@ -8,7 +8,7 @@ use App\User;
 use Illuminate\Support\Facades\Artisan;
 use Tests\TestCase;
 
-final class StatusCommandTest extends TestCase
+class StatusCommandTest extends TestCase
 {
     public function testStatus(): void
     {

--- a/tests/Features/SyncCommandTest.php
+++ b/tests/Features/SyncCommandTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Artisan;
 use Tests\Features\Fixtures\FakeException;
 use Tests\TestCase;
 
-final class SyncCommandTest extends TestCase
+class SyncCommandTest extends TestCase
 {
     public function testModelsAreDiscovered(): void
     {

--- a/tests/Features/TransformersTest.php
+++ b/tests/Features/TransformersTest.php
@@ -15,7 +15,7 @@ use Tests\Features\Fixtures\ThreadWithSearchableArray;
 use Tests\Features\Fixtures\ThreadWithSearchableArrayUsingTransform;
 use Tests\TestCase;
 
-final class TransformersTest extends TestCase
+class TransformersTest extends TestCase
 {
     public function testAppliedByDefault(): void
     {

--- a/tests/Features/UnsearchableTest.php
+++ b/tests/Features/UnsearchableTest.php
@@ -7,7 +7,7 @@ namespace Tests\Features;
 use App\User;
 use Tests\TestCase;
 
-final class UnsearchableTest extends TestCase
+class UnsearchableTest extends TestCase
 {
     public function testUnsearchable(): void
     {

--- a/tests/Features/WhereQueriesTest.php
+++ b/tests/Features/WhereQueriesTest.php
@@ -7,7 +7,7 @@ namespace Tests\Features;
 use App\User;
 use Tests\TestCase;
 
-final class WhereQueriesTest extends TestCase
+class WhereQueriesTest extends TestCase
 {
     public function testExplicitOperator(): void
     {

--- a/tests/laravel/app/All.php
+++ b/tests/laravel/app/All.php
@@ -4,7 +4,7 @@ namespace App;
 
 use Algolia\ScoutExtended\Searchable\Aggregator;
 
-final class All extends Aggregator
+class All extends Aggregator
 {
     protected $models = [
         User::class,

--- a/tests/laravel/app/EmptyItem.php
+++ b/tests/laravel/app/EmptyItem.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Laravel\Scout\Searchable;
 
-final class EmptyItem extends Model
+class EmptyItem extends Model
 {
     use SoftDeletes, Searchable;
 

--- a/tests/laravel/app/News.php
+++ b/tests/laravel/app/News.php
@@ -4,7 +4,7 @@ namespace App;
 
 use Algolia\ScoutExtended\Searchable\Aggregator;
 
-final class News extends Aggregator
+class News extends Aggregator
 {
     protected $models = [
         User::class,

--- a/tests/laravel/app/Post.php
+++ b/tests/laravel/app/Post.php
@@ -5,7 +5,7 @@ namespace App;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-final class Post extends Model
+class Post extends Model
 {
     use SoftDeletes;
 

--- a/tests/laravel/app/UnresolvableClass.php.stub
+++ b/tests/laravel/app/UnresolvableClass.php.stub
@@ -4,7 +4,7 @@ namespace App;
 
 use FromPackage\SomeBaseClass;
 
-final class UnresolvableClass extends SomeBaseClass
+class UnresolvableClass extends SomeBaseClass
 {
     // emmpty
 }

--- a/tests/laravel/app/User.php
+++ b/tests/laravel/app/User.php
@@ -6,7 +6,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Scout\Searchable;
 
-final class User extends Authenticatable
+class User extends Authenticatable
 {
     use Notifiable, Searchable;
 

--- a/tests/laravel/app/Wall.php
+++ b/tests/laravel/app/Wall.php
@@ -4,7 +4,7 @@ namespace App;
 
 use Algolia\ScoutExtended\Searchable\Aggregator;
 
-final class Wall extends Aggregator
+class Wall extends Aggregator
 {
     protected $models = [
         User::class,

--- a/tests/laravel/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/tests/laravel/database/migrations/2014_10_12_000000_create_users_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-final class CreateUsersTable extends Migration
+class CreateUsersTable extends Migration
 {
     public function up(): void
     {

--- a/tests/laravel/database/migrations/2014_10_12_000001_create_threads_table.php
+++ b/tests/laravel/database/migrations/2014_10_12_000001_create_threads_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-final class CreateThreadsTable extends Migration
+class CreateThreadsTable extends Migration
 {
     public function up(): void
     {

--- a/tests/laravel/database/migrations/2014_10_12_000002_create_posts_table.php
+++ b/tests/laravel/database/migrations/2014_10_12_000002_create_posts_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-final class CreatePostsTable extends Migration
+class CreatePostsTable extends Migration
 {
     public function up(): void
     {

--- a/tests/laravel/database/migrations/2014_10_12_000003_create_empty_items_table.php
+++ b/tests/laravel/database/migrations/2014_10_12_000003_create_empty_items_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-final class CreateEmptyItemsTable extends Migration
+class CreateEmptyItemsTable extends Migration
 {
     public function up(): void
     {

--- a/tests/laravel/database/migrations/2014_10_12_000003_create_terms_table.php
+++ b/tests/laravel/database/migrations/2014_10_12_000003_create_terms_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-final class CreateTermsTable extends Migration
+class CreateTermsTable extends Migration
 {
     public function up(): void
     {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     


## Describe your change
This removes the `final` keyword from all class definitions.

## What problem is this fixing?
Currently, it's impossible for users to extend the behavior of Scout Extended due to the `final` classes. Removing this keyword allows them to customise or replace the implementation of the class with something custom.