### PR TITLE
feat: Laravel 10 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,5 +95,5 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ['8.0', '8.1', '8.2']
+              version: ['8.1', '8.2']
               laravel: ['^10.0']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,15 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ['7.3', '7.4', '8.0', '8.1']
+              version: ['7.3', '7.4', '8.0', '8.1', '8.2']
               laravel: ['^8.0']
       - test:
           matrix:
             parameters:
-              version: ['8.0', '8.1']
+              version: ['8.0', '8.1', '8.2']
               laravel: ['^9.0']
+      - test:
+          matrix:
+            parameters:
+              version: ['8.0', '8.1', '8.2']
+              laravel: ['^10.0']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,11 +85,6 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ['7.3', '7.4', '8.0', '8.1', '8.2']
-              laravel: ['^8.0']
-      - test:
-          matrix:
-            parameters:
               version: ['8.0', '8.1', '8.2']
               laravel: ['^9.0']
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
     steps:
       - checkout
 
-      - run: sudo add-apt-repository ppa:ondrej/php
+      - run: sudo add-apt-repository ppa:ondrej/php -y
       - run: sudo apt-get update
       - run: sudo apt-get install -y php<<parameters.version>>-zip php<<parameters.version>>-sqlite3
       - restore_cache: *restore_cache

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "algolia/algoliasearch-client-php": "^3.0.0",
         "illuminate/console": "^9.0|^10.0",

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         "php": "^7.3|^8.0",
         "ext-json": "*",
         "algolia/algoliasearch-client-php": "^3.0.0",
-        "illuminate/console": "^8.0|^9.0",
-        "illuminate/contracts": "^8.0|^9.0",
-        "illuminate/database": "^8.0|^9.0",
-        "illuminate/filesystem": "^8.0|^9.0",
-        "illuminate/support": "^8.0|^9.0",
-        "laravel/scout": "^8.0|^9.0",
+        "illuminate/console": "^8.0|^9.0|^10.0",
+        "illuminate/contracts": "^8.0|^9.0|^10.0",
+        "illuminate/database": "^8.0|^9.0|^10.0",
+        "illuminate/filesystem": "^8.0|^9.0|^10.0",
+        "illuminate/support": "^8.0|^9.0|^10.0",
+        "laravel/scout": "^8.0|^9.0|^10.0",
         "riimu/kit-phpencoder": "^2.4"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         "php": "^7.3|^8.0",
         "ext-json": "*",
         "algolia/algoliasearch-client-php": "^3.0.0",
-        "illuminate/console": "^8.0|^9.0|^10.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0",
-        "illuminate/database": "^8.0|^9.0|^10.0",
-        "illuminate/filesystem": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0",
-        "laravel/scout": "^8.0|^9.0|^10.0",
+        "illuminate/console": "^9.0|^10.0",
+        "illuminate/contracts": "^9.0|^10.0",
+        "illuminate/database": "^9.0|^10.0",
+        "illuminate/filesystem": "^9.0|^10.0",
+        "illuminate/support": "^9.0|^10.0",
+        "laravel/scout": "^9.0|^10.0",
         "riimu/kit-phpencoder": "^2.4"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "fakerphp/faker": "^1.13",
         "mockery/mockery": "^1.4",
         "nunomaduro/larastan": "^1.0",
-        "orchestra/testbench": "^4.9|^5.9|^6.6|^7.0",
+        "orchestra/testbench": "^4.9|^5.9|^6.6|^7.0|^8.0",
         "phpstan/phpstan": "^1.3",
         "phpunit/phpunit": "^8.0|^9.0",
         "laravel/legacy-factories": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "fakerphp/faker": "^1.13",
         "mockery/mockery": "^1.4",
-        "nunomaduro/larastan": "^1.0",
+        "nunomaduro/larastan": "^1.0|^2.0",
         "orchestra/testbench": "^4.9|^5.9|^6.6|^7.0|^8.0",
         "phpstan/phpstan": "^1.3",
         "phpunit/phpunit": "^8.0|^9.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,5 +9,3 @@ parameters:
         - '#Illuminate\\Database\\Eloquent\\Model::searchableAs\(\)#'
         - '#Algolia\\ScoutExtended\\ScoutExtendedServiceProvider::getModel\(\)#'
         - '#Unsafe usage of new static#'
-        - '#Call to an undefined method Illuminate\\Support\\Collection<int, \$this\(Algolia\\ScoutExtended\\Searchable\\Aggregator\)>::searchable\(\).#'
-        - '#Call to an undefined method Illuminate\\Support\\Collection<int, \$this\(Algolia\\ScoutExtended\\Searchable\\Aggregator\)>::unsearchable\(\).#'

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -69,7 +69,7 @@ class AlgoliaEngine extends BaseAlgoliaEngine
      */
     public function update($searchables)
     {
-        dispatch_now(new UpdateJob($searchables));
+        dispatch_sync(new UpdateJob($searchables));
     }
 
     /**
@@ -77,7 +77,7 @@ class AlgoliaEngine extends BaseAlgoliaEngine
      */
     public function delete($searchables)
     {
-        dispatch_now(new DeleteJob($searchables));
+        dispatch_sync(new DeleteJob($searchables));
     }
 
     /**

--- a/src/Jobs/UpdateJob.php
+++ b/src/Jobs/UpdateJob.php
@@ -135,7 +135,7 @@ class UpdateJob
             }
         }
 
-        dispatch_now(new DeleteJob(collect($searchablesToDelete)));
+        dispatch_sync(new DeleteJob(collect($searchablesToDelete)));
 
         $result = $index->saveObjects($objectsToSave);
         if (config('scout.synchronous', false)) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | yes     
| Related Issue     | Fix #319 
| Need Doc update   | yes


## Describe your change
This adds support for the upcoming Laravel 10 release. This means dropping support for PHP `7.x`, as well as Laravel `8.x`. We also had to replace calls to the deprecated  `dispatch_now` to `dispatch_sync`.