### PR TITLE
Respect standard Scout Algolia config

### DIFF
--- a/src/Managers/EngineManager.php
+++ b/src/Managers/EngineManager.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Algolia\ScoutExtended\Managers;
 
+use Algolia\AlgoliaSearch\Config\SearchConfig;
 use Algolia\AlgoliaSearch\SearchClient;
 use Algolia\AlgoliaSearch\Support\UserAgent;
 use Algolia\ScoutExtended\Engines\AlgoliaEngine;
@@ -29,6 +30,29 @@ class EngineManager extends BaseEngineManager
     {
         UserAgent::addCustomUserAgent('Laravel Scout Extended', '3.0.0');
 
-        return new AlgoliaEngine(SearchClient::create(config('scout.algolia.id'), config('scout.algolia.secret')));
+        $config = SearchConfig::create(
+            config('scout.algolia.id'),
+            config('scout.algolia.secret')
+        )->setDefaultHeaders(
+            $this->defaultAlgoliaHeaders()
+        );
+
+        if (is_int($connectTimeout = config('scout.algolia.connect_timeout'))) {
+            $config->setConnectTimeout($connectTimeout);
+        }
+
+        if (is_int($readTimeout = config('scout.algolia.read_timeout'))) {
+            $config->setReadTimeout($readTimeout);
+        }
+
+        if (is_int($writeTimeout = config('scout.algolia.write_timeout'))) {
+            $config->setWriteTimeout($writeTimeout);
+        }
+
+        if (is_int($batchSize = config('scout.algolia.batch_size'))) {
+            $config->setBatchSize($batchSize);
+        }
+
+        return new AlgoliaEngine(SearchClient::createWithConfig($config));
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

This change ensures that standard Laravel Scout configuration for Algolia is respected when using Scout Extended.

## What problem is this fixing?

Base Laravel Scout allows you to control certain features of the search client through configuration, but Scout extended ignores those configuratiton options.

This change makes scout extended respect the `connect_timeout`, `read_timeout`, `write_timeout`, and `batch_size` configuration options.

I will note that base scout also doesn't currently pay attention to `batch_size`, but that's the one setting that we wanted to change in the first place. I have [opened a PR to scout](https://github.com/laravel/scout/pull/767) to address this issue there, too.