### PR TITLE
Use cimg/php native extension install script in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,9 +73,7 @@ jobs:
     steps:
       - checkout
 
-      - run: sudo add-apt-repository ppa:ondrej/php -y
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y php<<parameters.version>>-zip php<<parameters.version>>-sqlite3
+      - run: sudo -E install-php-extensions sqlite3 zip
       - restore_cache: *restore_cache
       - run: *install_dependencies
       - save_cache: *save_cache


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

Alter PHP extension installation in CI to use officially supported method.

See also https://github.com/CircleCI-Public/cimg-php/blob/main/README.md#php-extensions.

## What problem is this fixing?

In the current CI test job, PHP extensions are installed through the `ppa:ondrej/php` repository. Although a very useful repository, it is not suitable for this purpose, as the installed extensions are possibly incompatible with the installed PHP version due to using different source code versions. 

My assumption is that this currently goes undetected as the call currently causes an entire second PHP version to be installed, see e.g. https://app.circleci.com/pipelines/github/algolia/scout-extended/255/workflows/ec6dc973-ce16-4d43-82e8-a61c2b2b4cd4/jobs/2079/parallel-runs/0/steps/0-104.

Note: alternatively, the entire call could be removed, since both extensions are part of the base `cimg/php` image already. However, this may cause breakage in the future if the list of default extensions of this image is altered.


