### PR TITLE
Get correct `total` value when a callback is defined

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -182,4 +182,15 @@ class Builder extends BaseBuilder
 
         return $value;
     }
+
+    /**
+     * Get the total number of results from the engine.
+     *
+     * @param  mixed  $results
+     * @return int
+     */
+    protected function getTotalCount($results)
+    {
+        return $this->engine()->getTotalCount($results);
+    }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no / maybe?    
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

This PR overwrites that to always return the correct result count from the engine's results.

## What problem is this fixing?

The base Scout `Builder` class skips the engine's total hits value when a callback method is defined in the `search()` method.
