### PR TITLE
Refactored the DeleteJob to use 'deleteObjects' instead of 'deleteBy'

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,6 +6,6 @@ parameters:
         - src
     checkMissingIterableValueType: false
     ignoreErrors:
-        - '#Illuminate\\Database\\Eloquent\\Model::searchableAs\(\)#'
+        - '#Illuminate\\Database\\Eloquent\\Model::(searchableAs|searchableUsing)\(\)#'
         - '#Algolia\\ScoutExtended\\ScoutExtendedServiceProvider::getModel\(\)#'
         - '#Unsafe usage of new static#'

--- a/tests/Features/AggregatorTest.php
+++ b/tests/Features/AggregatorTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Features;
 
+use Algolia\AlgoliaSearch\RetryStrategy\ApiWrapper;
+use Algolia\AlgoliaSearch\Iterators\ObjectIterator;
 use Algolia\ScoutExtended\Searchable\Aggregator;
 use Algolia\ScoutExtended\Searchable\AggregatorCollection;
 use Algolia\ScoutExtended\Searchable\Aggregators;
@@ -31,10 +33,20 @@ class AggregatorTest extends TestCase
 
         $user = factory(User::class)->create();
 
-        $usersIndexMock->shouldReceive('deleteBy')->once()->with([
+        $usersIndexMock->shouldReceive('browseObjects')->once()->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['App\User::1'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'App\User::1'],
+        ]);
+        $usersIndexMock->shouldReceive('deleteObjects')->once()->with([
+            'App\User::1',
         ]);
 
         $user->delete();
@@ -57,16 +69,36 @@ class AggregatorTest extends TestCase
         }));
         $user = factory(User::class)->create();
 
-        $usersIndexMock->shouldReceive('deleteBy')->once()->with([
+        $usersIndexMock->shouldReceive('browseObjects')->once()->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['App\User::1'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'App\User::1'],
+        ]);
+        $usersIndexMock->shouldReceive('deleteObjects')->once()->with([
+            'App\User::1',
         ]);
 
-        $wallIndexMock->shouldReceive('deleteBy')->once()->with([
+        $wallIndexMock->shouldReceive('browseObjects')->once()->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['App\User::1'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'App\User::1'],
+        ]);
+        $wallIndexMock->shouldReceive('deleteObjects')->once()->with([
+            'App\User::1',
         ]);
 
         $user->delete();
@@ -86,17 +118,38 @@ class AggregatorTest extends TestCase
         }));
         $thread = factory(Thread::class)->create();
 
-        $threadIndexMock->shouldReceive('deleteBy')->once()->with([
+        $threadIndexMock->shouldReceive('browseObjects')->once()->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['App\Thread::1'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'App\Thread::1'],
+        ]);
+        $threadIndexMock->shouldReceive('deleteObjects')->once()->with([
+            'App\Thread::1',
         ]);
 
-        $wallIndexMock->shouldReceive('deleteBy')->once()->with([
+        $wallIndexMock->shouldReceive('browseObjects')->once()->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['App\Thread::1'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'App\Thread::1'],
         ]);
+        $wallIndexMock->shouldReceive('deleteObjects')->once()->with([
+            'App\Thread::1',
+        ]);
+
         $thread->delete();
     }
 
@@ -111,10 +164,20 @@ class AggregatorTest extends TestCase
             return count($argument) === 1 && array_key_exists('subject', $argument[0]) &&
                 $argument[0]['objectID'] === 'App\Post::1';
         }));
-        $wallIndexMock->shouldReceive('deleteBy')->times(3)->with([
+        $wallIndexMock->shouldReceive('browseObjects')->times(3)->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['App\Post::1'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'App\Post::1'],
+        ]);
+        $wallIndexMock->shouldReceive('deleteObjects')->times(3)->with([
+            'App\Post::1',
         ]);
         $post = factory(Post::class)->create();
         $post->delete();
@@ -138,11 +201,22 @@ class AggregatorTest extends TestCase
         $post = factory(Post::class)->create();
         $post->delete();
 
-        $wallIndexMock->shouldReceive('deleteBy')->once()->with([
+        $wallIndexMock->shouldReceive('browseObjects')->once()->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['App\Post::1'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'App\Post::1'],
         ]);
+        $wallIndexMock->shouldReceive('deleteObjects')->once()->with([
+            'App\Post::1',
+        ]);
+
         $post->forceDelete();
     }
 
@@ -250,22 +324,52 @@ class AggregatorTest extends TestCase
         }));
         $user = factory(User::class)->create();
 
-        $usersIndexMock->shouldReceive('deleteBy')->once()->with([
+        $usersIndexMock->shouldReceive('browseObjects')->once()->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['App\User::1'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'App\User::1'],
+        ]);
+        $usersIndexMock->shouldReceive('deleteObjects')->once()->with([
+            'App\User::1',
         ]);
 
-        $wallIndexMock->shouldReceive('deleteBy')->once()->with([
+        $wallIndexMock->shouldReceive('browseObjects')->once()->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['App\User::1'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'App\User::1'],
+        ]);
+        $wallIndexMock->shouldReceive('deleteObjects')->once()->with([
+            'App\User::1',
         ]);
 
-        $allIndexMock->shouldReceive('deleteBy')->once()->with([
+        $allIndexMock->shouldReceive('browseObjects')->once()->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['App\User::1'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'App\User::1'],
+        ]);
+        $allIndexMock->shouldReceive('deleteObjects')->once()->with([
+            'App\User::1',
         ]);
 
         $user->delete();

--- a/tests/Features/SplittersTest.php
+++ b/tests/Features/SplittersTest.php
@@ -25,10 +25,20 @@ class SplittersTest extends TestCase
                 $argument[0]['body'] === 'Hello Foo!' && $argument[1]['body'] === 'Hello Bar!';
         }))->andReturn($this->mockResponse());
 
-        $index->shouldReceive('deleteBy')->once()->with([
+        $index->shouldReceive('browseObjects')->once()->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['Tests\Features\Fixtures\ThreadWithSplitterClass::1'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'Tests\Features\Fixtures\ThreadWithSplitterClass::1'],
+        ]);
+        $index->shouldReceive('deleteObjects')->once()->with([
+            'Tests\Features\Fixtures\ThreadWithSplitterClass::1',
         ]);
 
         $body = implode('', [
@@ -50,10 +60,20 @@ class SplittersTest extends TestCase
                 $argument[0]['body'] === 'Hello Foo!' && $argument[1]['body'] === 'Hello Bar!';
         }))->andReturn($this->mockResponse());
 
-        $index->shouldReceive('deleteBy')->with([
+        $index->shouldReceive('browseObjects')->once()->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['Tests\Features\Fixtures\ThreadWithValueReturned::1'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'Tests\Features\Fixtures\ThreadWithValueReturned::1'],
+        ]);
+        $index->shouldReceive('deleteObjects')->once()->with([
+            'Tests\Features\Fixtures\ThreadWithValueReturned::1',
         ]);
 
         $body = implode(',', [
@@ -75,10 +95,20 @@ class SplittersTest extends TestCase
                 $argument[0]['body'] === 'Hello Foo!' && $argument[1]['body'] === 'Hello Bar!';
         }))->andReturn($this->mockResponse());
 
-        $index->shouldReceive('deleteBy')->with([
+        $index->shouldReceive('browseObjects')->once()->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['Tests\Features\Fixtures\ThreadWithSplitterInstance::1'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'Tests\Features\Fixtures\ThreadWithSplitterInstance::1'],
+        ]);
+        $index->shouldReceive('deleteObjects')->once()->with([
+            'Tests\Features\Fixtures\ThreadWithSplitterInstance::1',
         ]);
 
         $body = implode('', [
@@ -116,10 +146,20 @@ class SplittersTest extends TestCase
                 $argument[7]['slug'] === 'second' && $argument[7]['description_at_the_letter'] === 2;
         }))->andReturn($this->mockResponse());
 
-        $index->shouldReceive('deleteBy')->with([
+        $index->shouldReceive('browseObjects')->once()->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['Tests\Features\Fixtures\ThreadMultipleSplits::1'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'Tests\Features\Fixtures\ThreadMultipleSplits::1'],
+        ]);
+        $index->shouldReceive('deleteObjects')->once()->with([
+            'Tests\Features\Fixtures\ThreadMultipleSplits::1',
         ]);
 
         $body = implode('', [
@@ -139,7 +179,10 @@ class SplittersTest extends TestCase
         $index = $this->mockIndex(ThreadWithValueReturned::class);
 
         $index->shouldReceive('saveObjects')->twice();
-        $index->shouldReceive('deleteBy')->twice();
+        // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+        //       but mocking that class is not feasible as it has been declared `final`.
+        $index->shouldReceive('browseObjects')->twice()->andReturn([]);
+        $index->shouldReceive('deleteObjects')->twice();
 
         $body = implode('', [
             '<h1>Hello <strong>Foo!</strong></h1>',

--- a/tests/Features/SplittersTest.php
+++ b/tests/Features/SplittersTest.php
@@ -16,6 +16,8 @@ class SplittersTest extends TestCase
 {
     public function testRecordsAreSplittedByASplitter(): void
     {
+        $this->app['config']->set('scout.algolia.use_deprecated_delete_by', false);
+
         $index = $this->mockIndex(ThreadWithSplitterClass::class);
 
         $index->shouldReceive('saveObjects')->once()->with(Mockery::on(function ($argument) {
@@ -49,8 +51,35 @@ class SplittersTest extends TestCase
         ThreadWithSplitterClass::create(['body' => $body]);
     }
 
+    public function testRecordsAreSplittedByASplitterWithDeprecatedDeleteBy(): void
+    {
+        $index = $this->mockIndex(ThreadWithSplitterClass::class);
+
+        $index->shouldReceive('saveObjects')->once()->with(Mockery::on(function ($argument) {
+            return count($argument) === 2 &&
+                $argument[0]['objectID'] === 'Tests\Features\Fixtures\ThreadWithSplitterClass::1::0' &&
+                $argument[1]['objectID'] === 'Tests\Features\Fixtures\ThreadWithSplitterClass::1::1' &&
+                $argument[0]['body'] === 'Hello Foo!' && $argument[1]['body'] === 'Hello Bar!';
+        }))->andReturn($this->mockResponse());
+
+        $index->shouldReceive('deleteBy')->once()->with([
+            'tagFilters' => [
+                ['Tests\Features\Fixtures\ThreadWithSplitterClass::1'],
+            ],
+        ]);
+
+        $body = implode('', [
+            '<p>Hello <a href="example.com">Foo</a>!</p>',
+            '<p>Hello <a href="example.com">Bar</a>!</p>',
+        ]);
+
+        ThreadWithSplitterClass::create(['body' => $body]);
+    }
+
     public function testRecordsAreTextSplittedByValue(): void
     {
+        $this->app['config']->set('scout.algolia.use_deprecated_delete_by', false);
+
         $index = $this->mockIndex(ThreadWithValueReturned::class);
 
         $index->shouldReceive('saveObjects')->once()->with(Mockery::on(function ($argument) {
@@ -84,8 +113,35 @@ class SplittersTest extends TestCase
         ThreadWithValueReturned::create(['body' => $body]);
     }
 
+    public function testRecordsAreTextSplittedByValueWithDeprecatedDeleteBy(): void
+    {
+        $index = $this->mockIndex(ThreadWithValueReturned::class);
+
+        $index->shouldReceive('saveObjects')->once()->with(Mockery::on(function ($argument) {
+            return count($argument) === 2 &&
+                $argument[0]['objectID'] === 'Tests\Features\Fixtures\ThreadWithValueReturned::1::0' &&
+                $argument[1]['objectID'] === 'Tests\Features\Fixtures\ThreadWithValueReturned::1::1' &&
+                $argument[0]['body'] === 'Hello Foo!' && $argument[1]['body'] === 'Hello Bar!';
+        }))->andReturn($this->mockResponse());
+
+        $index->shouldReceive('deleteBy')->with([
+            'tagFilters' => [
+                ['Tests\Features\Fixtures\ThreadWithValueReturned::1'],
+            ],
+        ]);
+
+        $body = implode(',', [
+            'Hello Foo!',
+            'Hello Bar!',
+        ]);
+
+        ThreadWithValueReturned::create(['body' => $body]);
+    }
+
     public function testRecordsAreTextSplittedSplitterInstance(): void
     {
+        $this->app['config']->set('scout.algolia.use_deprecated_delete_by', false);
+
         $index = $this->mockIndex(ThreadWithSplitterInstance::class);
 
         $index->shouldReceive('saveObjects')->once()->with(Mockery::on(function ($argument) {
@@ -119,8 +175,35 @@ class SplittersTest extends TestCase
         ThreadWithSplitterInstance::create(['body' => $body]);
     }
 
+    public function testRecordsAreTextSplittedSplitterInstanceWithDeprecatedDeleteBy(): void
+    {
+        $index = $this->mockIndex(ThreadWithSplitterInstance::class);
+
+        $index->shouldReceive('saveObjects')->once()->with(Mockery::on(function ($argument) {
+            return count($argument) === 2 &&
+                $argument[0]['objectID'] === 'Tests\Features\Fixtures\ThreadWithSplitterInstance::1::0' &&
+                $argument[1]['objectID'] === 'Tests\Features\Fixtures\ThreadWithSplitterInstance::1::1' &&
+                $argument[0]['body'] === 'Hello Foo!' && $argument[1]['body'] === 'Hello Bar!';
+        }))->andReturn($this->mockResponse());
+
+        $index->shouldReceive('deleteBy')->with([
+            'tagFilters' => [
+                ['Tests\Features\Fixtures\ThreadWithSplitterInstance::1'],
+            ],
+        ]);
+
+        $body = implode('', [
+            '<h1>Hello <strong>Foo!</strong></h1>',
+            '<h1>Hello <strong>Bar</strong>!</h1>',
+        ]);
+
+        ThreadWithSplitterInstance::create(['body' => $body]);
+    }
+
     public function testRecordsCanHaveMultipleSplits(): void
     {
+        $this->app['config']->set('scout.algolia.use_deprecated_delete_by', false);
+
         $index = $this->mockIndex(ThreadMultipleSplits::class);
 
         $index->shouldReceive('saveObjects')->once()->with(Mockery::on(function ($argument) {
@@ -174,8 +257,55 @@ class SplittersTest extends TestCase
         ]);
     }
 
+    public function testRecordsCanHaveMultipleSplitsWithDeprecatedDeleteBy(): void
+    {
+        $index = $this->mockIndex(ThreadMultipleSplits::class);
+
+        $index->shouldReceive('saveObjects')->once()->with(Mockery::on(function ($argument) {
+            return count($argument) === 8 && $argument[0]['objectID'] === 'Tests\Features\Fixtures\ThreadMultipleSplits::1::0' &&
+                $argument[1]['objectID'] === 'Tests\Features\Fixtures\ThreadMultipleSplits::1::1' &&
+                $argument[2]['objectID'] === 'Tests\Features\Fixtures\ThreadMultipleSplits::1::2' &&
+                $argument[3]['objectID'] === 'Tests\Features\Fixtures\ThreadMultipleSplits::1::3' &&
+                $argument[4]['objectID'] === 'Tests\Features\Fixtures\ThreadMultipleSplits::1::4' &&
+                $argument[5]['objectID'] === 'Tests\Features\Fixtures\ThreadMultipleSplits::1::5' &&
+                $argument[6]['objectID'] === 'Tests\Features\Fixtures\ThreadMultipleSplits::1::6' &&
+                $argument[7]['objectID'] === 'Tests\Features\Fixtures\ThreadMultipleSplits::1::7' &&
+                $argument[0]['body'] === 'Hello Foo!' && $argument[0]['slug'] === 'first' &&
+                $argument[0]['description_at_the_letter'] === 1 && $argument[1]['body'] === 'Hello Bar!' &&
+                $argument[1]['slug'] === 'first' && $argument[1]['description_at_the_letter'] === 1 &&
+                $argument[2]['body'] === 'Hello Foo!' && $argument[2]['slug'] === 'first' &&
+                $argument[2]['description_at_the_letter'] === 2 && $argument[3]['body'] === 'Hello Bar!' &&
+                $argument[3]['slug'] === 'first' && $argument[3]['description_at_the_letter'] === 2 &&
+                $argument[4]['body'] === 'Hello Foo!' && $argument[4]['slug'] === 'second' &&
+                $argument[4]['description_at_the_letter'] === 1 && $argument[5]['body'] === 'Hello Bar!' &&
+                $argument[5]['slug'] === 'second' && $argument[5]['description_at_the_letter'] === 1 &&
+                $argument[6]['body'] === 'Hello Foo!' && $argument[6]['slug'] === 'second' &&
+                $argument[6]['description_at_the_letter'] === 2 && $argument[7]['body'] === 'Hello Bar!' &&
+                $argument[7]['slug'] === 'second' && $argument[7]['description_at_the_letter'] === 2;
+        }))->andReturn($this->mockResponse());
+
+        $index->shouldReceive('deleteBy')->with([
+            'tagFilters' => [
+                ['Tests\Features\Fixtures\ThreadMultipleSplits::1'],
+            ],
+        ]);
+
+        $body = implode('', [
+            '<h1>Hello <strong>Foo!</strong></h1>',
+            '<h1>Hello <strong>Bar</strong>!</h1>',
+        ]);
+
+        ThreadMultipleSplits::create([
+            'slug' => 'first-second',
+            'description_at_the_letter' => 2,
+            'body' => $body,
+        ]);
+    }
+
     public function testSearchMethod(): void
     {
+        $this->app['config']->set('scout.algolia.use_deprecated_delete_by', false);
+
         $index = $this->mockIndex(ThreadWithValueReturned::class);
 
         $index->shouldReceive('saveObjects')->twice();
@@ -183,6 +313,46 @@ class SplittersTest extends TestCase
         //       but mocking that class is not feasible as it has been declared `final`.
         $index->shouldReceive('browseObjects')->twice()->andReturn([]);
         $index->shouldReceive('deleteObjects')->twice();
+
+        $body = implode('', [
+            '<h1>Hello <strong>Foo!</strong></h1>',
+            '<h1>Hello <strong>Bar</strong>!</h1>',
+        ]);
+
+        ThreadWithValueReturned::create(['body' => $body]);
+        ThreadWithValueReturned::create(['body' => 'Hello John']);
+
+        $index->shouldReceive('search')->once()->andReturn([
+            'hits' => [
+                [
+                    'body' => 'Hello Foo!',
+                    'id' => 1,
+                    'objectID' => "Tests\Features\Fixtures\ThreadWithValueReturned::1::0",
+                ],
+                [
+                    'body' => 'Hello Bar!',
+                    'id' => 1,
+                    'objectID' => "Tests\Features\Fixtures\ThreadWithValueReturned::1::1",
+                ],
+                [
+                    'body' => 'Hello John!',
+                    'id' => 2,
+                    'objectID' => "Tests\Features\Fixtures\ThreadWithValueReturned::2::0",
+                ],
+            ],
+        ]);
+        $models = ThreadWithValueReturned::search('Hello')->get();
+        $this->assertSame(3, $models->count());
+        $this->assertInstanceOf(ThreadWithValueReturned::class, $models[0]);
+        $this->assertInstanceOf(ThreadWithValueReturned::class, $models[1]);
+    }
+
+    public function testSearchMethodWithDeprecatedDeleteBy(): void
+    {
+        $index = $this->mockIndex(ThreadWithValueReturned::class);
+
+        $index->shouldReceive('saveObjects')->twice();
+        $index->shouldReceive('deleteBy')->twice();
 
         $body = implode('', [
             '<h1>Hello <strong>Foo!</strong></h1>',

--- a/tests/Features/UnsearchableTest.php
+++ b/tests/Features/UnsearchableTest.php
@@ -14,10 +14,24 @@ class UnsearchableTest extends TestCase
         factory(User::class, 5)->create();
 
         $usersIndex = $this->mockIndex(User::class);
-        $usersIndex->shouldReceive('deleteBy')->once()->with([
+        $usersIndex->shouldReceive('browseObjects')->once()->with([
+            'attributesToRetrieve' => [
+                'objectID',
+            ],
             'tagFilters' => [
                 ['App\User::1', 'App\User::2', 'App\User::3', 'App\User::4', 'App\User::5'],
             ],
+            // NOTE: This _should_ ideally return an instance of `\Algolia\AlgoliaSearch\Iterators\ObjectIterator`
+            //       but mocking that class is not feasible as it has been declared `final`.
+        ])->andReturn([
+            ['objectID' => 'App\User::1'],
+            ['objectID' => 'App\User::2'],
+            ['objectID' => 'App\User::3'],
+            ['objectID' => 'App\User::4'],
+            ['objectID' => 'App\User::5'],
+        ]);
+        $usersIndex->shouldReceive('deleteObjects')->once()->with([
+            'App\User::1', 'App\User::2', 'App\User::3', 'App\User::4', 'App\User::5'
         ]);
 
         User::get()->unsearchable();

--- a/tests/Features/UnsearchableTest.php
+++ b/tests/Features/UnsearchableTest.php
@@ -11,6 +11,8 @@ class UnsearchableTest extends TestCase
 {
     public function testUnsearchable(): void
     {
+        $this->app['config']->set('scout.algolia.use_deprecated_delete_by', false);
+
         factory(User::class, 5)->create();
 
         $usersIndex = $this->mockIndex(User::class);
@@ -32,6 +34,20 @@ class UnsearchableTest extends TestCase
         ]);
         $usersIndex->shouldReceive('deleteObjects')->once()->with([
             'App\User::1', 'App\User::2', 'App\User::3', 'App\User::4', 'App\User::5'
+        ]);
+
+        User::get()->unsearchable();
+    }
+
+    public function testUnsearchableWithDeprecatedDeleteBy(): void
+    {
+        factory(User::class, 5)->create();
+
+        $usersIndex = $this->mockIndex(User::class);
+        $usersIndex->shouldReceive('deleteBy')->once()->with([
+            'tagFilters' => [
+                ['App\User::1', 'App\User::2', 'App\User::3', 'App\User::4', 'App\User::5'],
+            ],
         ]);
 
         User::get()->unsearchable();


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #311
| Need Doc update   | yes


## Describe your change

This change is to account for the fact that the 'deleteBy' method has been deprecated on the new NeuralSearch infrastructure.

We have been advised of this by the Algolia support team and they have stated that it's a requirement in order to use the new infrastructure.

This update should also address the issue outlined in https://github.com/algolia/scout-extended/issues/311 
