### PR TITLE
Set scout configuration in engine manager

### DIFF
--- a/src/Managers/EngineManager.php
+++ b/src/Managers/EngineManager.php
@@ -17,6 +17,7 @@ use Algolia\AlgoliaSearch\SearchClient;
 use Algolia\AlgoliaSearch\Support\UserAgent;
 use Algolia\ScoutExtended\Engines\AlgoliaEngine;
 use Laravel\Scout\EngineManager as BaseEngineManager;
+use Algolia\AlgoliaSearch\Config\SearchConfig;
 
 class EngineManager extends BaseEngineManager
 {
@@ -29,6 +30,55 @@ class EngineManager extends BaseEngineManager
     {
         UserAgent::addCustomUserAgent('Laravel Scout Extended', '3.0.0');
 
-        return new AlgoliaEngine(SearchClient::create(config('scout.algolia.id'), config('scout.algolia.secret')));
+        $config = SearchConfig::create(
+            config('scout.algolia.id'),
+            config('scout.algolia.secret')
+        )->setDefaultHeaders(
+            $this->defaultAlgoliaHeaders()
+        );
+
+        if (is_int($connectTimeout = config('scout.algolia.connect_timeout'))) {
+            $config->setConnectTimeout($connectTimeout);
+        }
+
+        if (is_int($readTimeout = config('scout.algolia.read_timeout'))) {
+            $config->setReadTimeout($readTimeout);
+        }
+
+        if (is_int($writeTimeout = config('scout.algolia.write_timeout'))) {
+            $config->setWriteTimeout($writeTimeout);
+        }
+
+        if (is_int($batchSize = config('scout.algolia.batch_size'))) {
+            $config->setBatchSize($batchSize);
+        }
+
+        return new AlgoliaEngine(SearchClient::createWithConfig($config));
+    }
+
+    /**
+     * Set the default Algolia configuration headers.
+     *
+     * @return array
+     */
+    protected function defaultAlgoliaHeaders()
+    {
+        if (! config('scout.identify')) {
+            return [];
+        }
+
+        $headers = [];
+
+        if (! config('app.debug') &&
+            filter_var($ip = request()->ip(), FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)
+        ) {
+            $headers['X-Forwarded-For'] = $ip;
+        }
+
+        if (($user = request()->user()) && method_exists($user, 'getKey')) {
+            $headers['X-Algolia-UserToken'] = $user->getKey();
+        }
+
+        return $headers;
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no 
| BC breaks?        | no     
| Related Issue     | Fix #323 
| Need Doc update   | no


## Describe your change

Algolia's analytics dashboard cannot recognise user searches because the application doesn't send the `X-Algolia-UserToken` header when performing searches. Even when configuring `SCOUT_IDENTIFY` env var to true, it breaks the documented Laravel scout functionality.

## What problem is this fixing?

This update adds basic search client configuration to the engine manager while respecting Laravel Scout configurations.