### PR TITLE
Optimizes the ModelsResolver class

### DIFF
--- a/src/Searchable/ModelsResolver.php
+++ b/src/Searchable/ModelsResolver.php
@@ -85,18 +85,16 @@ class ModelsResolver
 
         $result = $searchable->newCollection();
 
+        $instances = $instances->keyBy(fn ($i) => ObjectIdEncrypter::encrypt($i));
         foreach ($hits as $id => $hit) {
-            foreach ($instances as $instance) {
-                if (ObjectIdEncrypter::encrypt($instance) === ObjectIdEncrypter::withoutPart((string) $id)) {
-                    if (method_exists($instance, 'withScoutMetadata')) {
-                        foreach (Arr::only($hit, self::$metadata) as $metadataKey => $metadataValue) {
-                            $instance->withScoutMetadata($metadataKey, $metadataValue);
-                        }
+            if ($i = $instances->get(ObjectIdEncrypter::withoutPart((string) $id))) {
+                if (method_exists($i, 'withScoutMetadata')) {
+                    foreach (Arr::only($hit, self::$metadata) as $metadataKey => $metadataValue) {
+                        $i->withScoutMetadata($metadataKey, $metadataValue);
                     }
-
-                    $result->push($instance);
-                    break;
                 }
+
+                $result->push($i);
             }
         }
 


### PR DESCRIPTION

| Q                 | A
| ----------------- | ----------
| Bug fix?          | No
| New feature?      | No
| BC breaks?        | No
| Related Issue     | N/a
| Need Doc update   | No


## Describe your change

Improves the performance of populating results in the ModelResolver class

## What problem is this fixing?

ModelResolver was executing a ~O(n^2) loop for populating scout metadata and building the results collection.

This was causing some scout searches to take 5+ seconds for us.

This fix changes the result collection construction to ~O(n), yielding a 100%-500% speed improvement in our local tests.