### PR TITLE
Fix conflict with Laravel/Scout v10.11.6 and newer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/database": "^9.0|^10.0|^11.0",
         "illuminate/filesystem": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0",
-        "laravel/scout": "^9.0||^10.0|<=10.11.5",
+        "laravel/scout": "^9.0|^10.0 <10.11.6",
         "riimu/kit-phpencoder": "^2.4"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/database": "^9.0|^10.0|^11.0",
         "illuminate/filesystem": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0",
-        "laravel/scout": "^9.0|^10.0 <=10.11.5",
+        "laravel/scout": "^9.0||^10.0|<=10.11.5",
         "riimu/kit-phpencoder": "^2.4"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/database": "^9.0|^10.0|^11.0",
         "illuminate/filesystem": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0",
-        "laravel/scout": "^9.0|^10.0|<10.11.7",
+        "laravel/scout": "^9.0|^10.0 <=10.11.5",
         "riimu/kit-phpencoder": "^2.4"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/database": "^9.0|^10.0|^11.0",
         "illuminate/filesystem": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0",
-        "laravel/scout": "^9.0|^10.0",
+        "laravel/scout": "^9.0|^10.0|<10.11.7",
         "riimu/kit-phpencoder": "^2.4"
     },
     "suggest": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,5 +7,4 @@ parameters:
     checkMissingIterableValueType: false
     ignoreErrors:
         - '#Illuminate\\Database\\Eloquent\\Model::(searchableAs|searchableUsing)\(\)#'
-        - '#Algolia\\ScoutExtended\\ScoutExtendedServiceProvider::getModel\(\)#'
         - '#Unsafe usage of new static#'


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #347, [#883](https://github.com/laravel/scout/issues/883), [#855](https://github.com/laravel/scout/issues/855)
| Need Doc update   | no


## Describe your change

Downgraded `laravel/scout` to version v10.11.5 in composer.json to resolve a conflict with the Algolia Search Client.

### Details 

This change addresses compatibility issues between [Laravel Scout v10.11.6 (and newer)](https://packagist.org/packages/laravel/scout#v10.11.6) and recent versions Algolia Search Client, ensuring stable integration.

The proposed solution is to downgrade downgrade dependency [Laravel Scout to v10.11.5](https://packagist.org/packages/laravel/scout#v10.11.5).

### Related Issues

- [Incompatible with `laravel/scout` v10.11.6 #347](https://github.com/algolia/scout-extended/issues/347)
- [Abstract method `performSearch` and `deleteIndex` are not implemented #883](https://github.com/laravel/scout/issues/883)
- [Algolia Search PHP Client v4 is not Compatible #855](https://github.com/laravel/scout/issues/855)

### Context

Laravel Scout [v10.11.6](https://packagist.org/packages/laravel/scout#v10.11.6) and [v10.11.7](https://packagist.org/packages/laravel/scout#v10.11.7) have conflicts with all recent versions of [Algolia Search Client](https://packagist.org/packages/algolia/algoliasearch-client-php).

```
    "conflict": {
        "algolia/algoliasearch-client-php": "<3.2.0|>=5.0.0"
    },

```