### PR TITLE
Support newer versions of laravel scout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/database": "^9.0|^10.0|^11.0",
         "illuminate/filesystem": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0",
-        "laravel/scout": "^9.0|^10.0 <10.11.6",
+        "laravel/scout": "^9.0|^10.0",
         "riimu/kit-phpencoder": "^2.4"
     },
     "suggest": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,7 +4,10 @@ parameters:
     level: 5
     paths:
         - src
-    checkMissingIterableValueType: false
+    treatPhpDocTypesAsCertain: false
+    excludePaths:
+            - src/Engines/AlgoliaEngine.php
     ignoreErrors:
         - '#Illuminate\\Database\\Eloquent\\Model::(searchableAs|searchableUsing)\(\)#'
         - '#Unsafe usage of new static#'
+        - '#Return type \(Algolia\\ScoutExtended\\Engines\\AlgoliaEngine\) of method Algolia\\ScoutExtended\\Managers\\EngineManager::createAlgoliaDriver\(\) should be compatible with return type \(Laravel\\Scout\\Engines\\AlgoliaEngine\) of method Laravel\\Scout\\EngineManager::createAlgoliaDriver\(\)#'

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -25,7 +25,7 @@ use Laravel\Scout\Scout;
 use function is_array;
 use Laravel\Scout\Builder;
 
-if (Scout::VERSION >= '10.11.6') {
+if (version_compare(Scout::VERSION, '10.11.6', '>=')) {
     // New Laravel Scout base class for Algolia
     class_alias(Algolia3Engine::class, BaseAlgoliaEngine::class);
 } else {

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -20,9 +20,18 @@ use Algolia\ScoutExtended\Searchable\ModelsResolver;
 use Algolia\ScoutExtended\Searchable\ObjectIdEncrypter;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
+use Laravel\Scout\Engines\Algolia3Engine;
+use Laravel\Scout\Scout;
 use function is_array;
 use Laravel\Scout\Builder;
-use Laravel\Scout\Engines\AlgoliaEngine as BaseAlgoliaEngine;
+
+if (Scout::VERSION >= '10.11.6') {
+    // New Laravel Scout base class for Algolia
+    class_alias(Algolia3Engine::class, BaseAlgoliaEngine::class);
+} else {
+    // Legacy Laravel Scout class
+    class_alias(\Laravel\Scout\Engines\AlgoliaEngine::class, BaseAlgoliaEngine::class);
+}
 
 class AlgoliaEngine extends BaseAlgoliaEngine
 {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #347 
| Need Doc update   | no


## Describe your change

My change is backwards compatible and supports newer versions of laravel/scout by aliasing the proper extended class.

## What problem is this fixing?

Laravel Scout created a v3 and v4 version of the Algolia Engine, and made the AlgoliaEngine class itself abstract. This was introduced in version 10.11.6 of laravel/scout.

A previous PR just ensured that scout would stay lower than `10.11.6`, but this change allows for newer versions. This will become more important in a few weeks when Laravel 12 is released and it requires a newer version of laravel scout than 10.11.5.
