### PR TITLE
Fix AggregatorObserver sync status

### DIFF
--- a/src/Searchable/AggregatorObserver.php
+++ b/src/Searchable/AggregatorObserver.php
@@ -85,10 +85,6 @@ class AggregatorObserver extends BaseModelObserver
      */
     public function deleted($model): void
     {
-        if (static::syncingDisabledFor($model)) {
-            return;
-        }
-
         if ($this->usesSoftDelete($model) && config('scout.soft_delete', false)) {
             $this->saved($model);
         } else {
@@ -112,10 +108,6 @@ class AggregatorObserver extends BaseModelObserver
      */
     public function forceDeleted($model): void
     {
-        if (static::syncingDisabledFor($model)) {
-            return;
-        }
-
         $class = get_class($model);
 
         if (! array_key_exists($class, $this->aggregators)) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    
| BC breaks?        | no     
| Related Issue     | Fix #285 and #301
| Need Doc update   | no

## Describe your change
Currently, the `deleted` and `forceDeleted` event handlers are disabled in `AggregatorObserver` if `disableSearchSyncing` has been set for an aggregator model. This should only disable the event handlers for the aggregator **models** and not the event handlers for aggregator **class** itself.  For this `disableSearchSyncing` should only be handled by the `ModelObserver` and not by the `AggregatorObserver` like it is currently implemented with the `saved` event handler in `ModelObserver` and `AggregatorObserver`.

## What problem is this fixing?
Currently, if multiple models are used in one index by using an aggregator and you don't want these to sync also by using `disableSearchSyncing`, these models won't be removed from the index on a delete, because the `AggregatorObserver` respects the disableSearchSyncing from its models while this should be respected by the `ModelObserver` only.

See [Multiple models in one index](https://www.algolia.com/doc/framework-integration/laravel/advanced-use-cases/multiple-models-in-one-index/) article for feature reference.
