### PR TITLE
fix: check if index exists before force creating

### DIFF
--- a/src/Console/Commands/ReImportCommand.php
+++ b/src/Console/Commands/ReImportCommand.php
@@ -103,7 +103,9 @@ class ReImportCommand extends Command
                     $response->wait();
                 }
             } catch (NotFoundException $e) {
-                $index->setSettings(['attributesForFaceting' => null])->wait();
+                if (!$index->exists()) {
+                    $index->setSettings(['attributesForFaceting' => null])->wait();
+                }
             }
         }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     

## Describe your change
This ensures we don't force override some settings in case one of the nodes has a slight delay in indexing and the temporary index may not be present on that specific node yet.
