### PR TITLE
Add syncing disabled for to aggregator

### DIFF
--- a/src/Searchable/AggregatorObserver.php
+++ b/src/Searchable/AggregatorObserver.php
@@ -76,6 +76,9 @@ class AggregatorObserver extends BaseModelObserver
         }
 
         foreach ($this->aggregators[$class] as $aggregator) {
+            if (static::syncingDisabledFor($aggregator)) {
+                continue;
+            }
             parent::saved($aggregator::create($model));
         }
     }
@@ -95,6 +98,9 @@ class AggregatorObserver extends BaseModelObserver
             }
 
             foreach ($this->aggregators[$class] as $aggregator) {
+                if (static::syncingDisabledFor($aggregator)) {
+                    continue;
+                }
                 $aggregator::create($model)->unsearchable();
             }
         }
@@ -115,6 +121,9 @@ class AggregatorObserver extends BaseModelObserver
         }
 
         foreach ($this->aggregators[$class] as $aggregator) {
+            if (static::syncingDisabledFor($aggregator)) {
+                continue;
+            }
             $aggregator::create($model)->unsearchable();
         }
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | https://github.com/algolia/scout-extended/pull/356
| Need Doc update   | no

This adds `syncingDisabledFor` functionality to the `AggregatorObserver` class. Momentarily this is only implemented and used for aggregator models. But because this class inherits from the `ModelObserver` the `disableSyncingFor` could be potentially enabled for aggregator classes as well, for which this functionality is needed.

## What problem is this fixing?
If you set enable `syncingDisabledFor` for an aggregator class it has no effect. This PR fixes this by implementing functionality so that aggregator classes also can have `syncingDisabledFor` enabled.