### PR TITLE
fix INF and NaN errors

### DIFF
--- a/src/Transformers/ConvertNumericStringsToNumbers.php
+++ b/src/Transformers/ConvertNumericStringsToNumbers.php
@@ -33,7 +33,17 @@ class ConvertNumericStringsToNumbers implements TransformerContract
              * Casts numeric strings to integers/floats.
              */
             if (is_string($value) && is_numeric($value)) {
-                $array[$key] = ctype_digit($value) ? (int) $value : (float) $value;
+                $number = ctype_digit($value) ? (int) $value : (float) $value;
+
+                if ($number === INF) {
+                    continue;
+                }
+
+                if (is_nan($number)) {
+                    continue;
+                }
+
+                $array[$key] = $number;
             }
         }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no   
| Related Issue     | Fix #223 
| Need Doc update   | no


## Describe your change

Check if a string that was cast to a number is NaN or INF and don't store it in the transformed array.

## What problem is this fixing?

Converting all numeric strings, is causing errors when a numeric string casts as a float to `INF` or `NaN`. This causes this package to crash the app. These attributes should just be left as strings.

Here's an example:

```
is_numeric('5929e536'); // true
(float) '5929e536'; // INF
```