### PR TITLE
feat: Update to scout v11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/filesystem": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "laravel/scout": "^11.1.0",
+        "laravel/scout": "^11.0.0",
         "riimu/kit-phpencoder": "^2.4"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/filesystem": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "laravel/scout": "^11.0",
+        "laravel/scout": "^11.1.0",
         "riimu/kit-phpencoder": "^2.4"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/filesystem": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "laravel/scout": "^10.11.6",
+        "laravel/scout": "^11.0",
         "riimu/kit-phpencoder": "^2.4"
     },
     "suggest": {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -88,6 +88,9 @@ class Builder extends BaseBuilder
     /**
      * Customize the search adding a where between clause.
      *
+     * Passes an array [min, max] as the where value (Scout v11 normally expects a scalar) so that
+     * AlgoliaEngine::filters() can render Algolia's range syntax: "field: min TO max".
+     *
      * @param  string $field
      * @param  array $values
      *

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -75,14 +75,11 @@ class Builder extends BaseBuilder
      */
     public function where($field, $operator, $value = null): self
     {
-        // Here we will make some assumptions about the operator. If only 2 values are
-        // passed to the method, we will assume that the operator is an equals sign
-        // and keep going. Otherwise, we'll require the operator to be passed in.
         if (func_num_args() === 2) {
             return parent::where($field, $this->transform($operator));
         }
 
-        return parent::where($field, "$operator {$this->transform($value)}");
+        return parent::where($field, $operator, $this->transform($value));
     }
 
     /**
@@ -95,7 +92,7 @@ class Builder extends BaseBuilder
      */
     public function whereBetween($field, array $values): self
     {
-        return $this->where("$field:", "{$this->transform($values[0])} TO {$this->transform($values[1])}");
+        return parent::where($field, ':', [$this->transform($values[0]), $this->transform($values[1])]);
     }
 
     /**
@@ -108,17 +105,7 @@ class Builder extends BaseBuilder
      */
     public function whereIn($field, $values): self
     {
-        if (! empty($values)) {
-            $wheres = array_map(function ($value) use ($field) {
-                return "$field={$this->transform($value)}";
-            }, array_values($values));
-        } else {
-            $wheres = ['0 = 1'];
-        }
-
-        $this->wheres[] = $wheres;
-
-        return $this;
+        return parent::whereIn($field, array_map(fn ($v) => $this->transform($v), array_values((array) $values)));
     }
 
     /**

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -75,6 +75,9 @@ class Builder extends BaseBuilder
      */
     public function where($field, $operator, $value = null): self
     {
+        // Here we will make some assumptions about the operator. If only 2 values are
+        // passed to the method, we will assume that the operator is an equals sign
+        // and keep going. Otherwise, we'll require the operator to be passed in.
         if (func_num_args() === 2) {
             return parent::where($field, $this->transform($operator));
         }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -112,6 +112,19 @@ class Builder extends BaseBuilder
     }
 
     /**
+     * Customize the search adding a where not in clause.
+     *
+     * @param  string $field
+     * @param  array $values
+     *
+     * @return $this
+     */
+    public function whereNotIn($field, $values): self
+    {
+        return parent::whereNotIn($field, array_map(fn ($v) => $this->transform($v), array_values((array) $values)));
+    }
+
+    /**
      * Add an optional filter to the search parameters.
      *
      * @link https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -117,6 +117,12 @@ class AlgoliaEngine extends Algolia4Engine
                 : '('.implode(' OR ', array_map(fn ($v) => "$field=$v", $values)).')';
         }
 
+        foreach ($builder->whereNotIns as $field => $values) {
+            if (! empty($values)) {
+                $parts[] = 'NOT ('.implode(' OR ', array_map(fn ($v) => "$field=$v", $values)).')';
+            }
+        }
+
         foreach ($builder->wheres as ['field' => $field, 'operator' => $operator, 'value' => $value]) {
             $parts[] = match ($operator) {
                 ':' => "$field: {$value[0]} TO {$value[1]}",

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -64,29 +64,6 @@ class AlgoliaEngine extends Algolia4Engine
     /**
      * {@inheritdoc}
      */
-    public function search(Builder $builder)
-    {
-        return $this->performSearch($builder, array_filter([
-            'filters' => $this->filters($builder),
-            'hitsPerPage' => $builder->limit,
-        ]));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function paginate(Builder $builder, $perPage, $page)
-    {
-        return $this->performSearch($builder, [
-            'filters' => $this->filters($builder),
-            'hitsPerPage' => $perPage,
-            'page' => $page - 1,
-        ]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function map(Builder $builder, $results, $searchable)
     {
         if (count($results['hits']) === 0) {

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -19,7 +19,6 @@ use Algolia\ScoutExtended\Jobs\UpdateJob;
 use Algolia\ScoutExtended\Searchable\ModelsResolver;
 use Algolia\ScoutExtended\Searchable\ObjectIdEncrypter;
 use Illuminate\Support\LazyCollection;
-use Illuminate\Support\Str;
 use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\Algolia4Engine;
 use function is_array;
@@ -68,7 +67,7 @@ class AlgoliaEngine extends Algolia4Engine
     public function search(Builder $builder)
     {
         return $this->performSearch($builder, array_filter([
-            'numericFilters' => $this->filters($builder),
+            'filters' => $this->filters($builder),
             'hitsPerPage' => $builder->limit,
         ]));
     }
@@ -79,7 +78,7 @@ class AlgoliaEngine extends Algolia4Engine
     public function paginate(Builder $builder, $perPage, $page)
     {
         return $this->performSearch($builder, [
-            'numericFilters' => $this->filters($builder),
+            'filters' => $this->filters($builder),
             'hitsPerPage' => $perPage,
             'page' => $page - 1,
         ]);
@@ -106,23 +105,27 @@ class AlgoliaEngine extends Algolia4Engine
     }
 
     /**
-     * @return array
+     * @return string
      */
-    protected function filters(Builder $builder)
+    protected function filters(Builder $builder): string
     {
-        $operators = ['<', '<=', '=', '!=', '>=', '>', ':'];
+        $parts = [];
 
-        return collect($builder->wheres)->map(function ($value, $key) use ($operators) {
-            if (! is_array($value)) {
-                if (Str::endsWith($key, $operators) || Str::startsWith($value, $operators)) {
-                    return $key.' '.$value;
-                }
+        foreach ($builder->whereIns as $field => $values) {
+            $parts[] = empty($values)
+                ? '(0 = 1)'
+                : '('.implode(' OR ', array_map(fn ($v) => "$field=$v", $values)).')';
+        }
 
-                return $key.'='.$value;
-            }
+        foreach ($builder->wheres as ['field' => $field, 'operator' => $operator, 'value' => $value]) {
+            $parts[] = match ($operator) {
+                ':' => "$field: {$value[0]} TO {$value[1]}",
+                '=' => "$field=$value",
+                default => "$field $operator $value",
+            };
+        }
 
-            return $value;
-        })->values()->all();
+        return implode(' AND ', $parts);
     }
 
     /**

--- a/tests/Features/WhereQueriesTest.php
+++ b/tests/Features/WhereQueriesTest.php
@@ -15,34 +15,10 @@ class WhereQueriesTest extends TestCase
         $this->mockIndex(User::class)
             ->shouldReceive('searchSingleIndex')
             ->once()
-            ->with('users', Mockery::subset(['query' => 'foo', 'numericFilters' => ['views_count != 100']]))
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => 'views_count != 100']))
             ->andReturn(['hits' => []]);
 
         User::search('foo')->where('views_count', '!=', '100')->get();
-    }
-
-    public function testInlineOperators(): void
-    {
-        $this->mockIndex(User::class)
-            ->shouldReceive('searchSingleIndex')
-            ->once()
-            ->with('users', Mockery::subset(['query' => 'foo', 'numericFilters' => ['views_count > 100']]))
-            ->andReturn(['hits' => []]);
-
-        User::search('foo')->where('views_count', '> 100')->get();
-    }
-
-    public function testWithDates(): void
-    {
-        $this->mockIndex(User::class)
-            ->shouldReceive('searchSingleIndex')
-            ->once()
-            ->with('users', Mockery::subset(['query' => 'foo', 'numericFilters' => [
-                'views_count > '.($date = now())->getTimestamp(),
-            ]]))
-            ->andReturn(['hits' => []]);
-
-        User::search('foo')->where('views_count', '>', $date)->get();
     }
 
     public function testOmittedOperator(): void
@@ -50,10 +26,21 @@ class WhereQueriesTest extends TestCase
         $this->mockIndex(User::class)
             ->shouldReceive('searchSingleIndex')
             ->once()
-            ->with('users', Mockery::subset(['query' => 'foo', 'numericFilters' => ['views_count=100']]))
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => 'views_count=100']))
             ->andReturn(['hits' => []]);
 
         User::search('foo')->where('views_count', '100')->get();
+    }
+
+    public function testWithDates(): void
+    {
+        $this->mockIndex(User::class)
+            ->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => 'views_count > '.($date = now())->getTimestamp()]))
+            ->andReturn(['hits' => []]);
+
+        User::search('foo')->where('views_count', '>', $date)->get();
     }
 
     public function testWhereBetween(): void
@@ -61,7 +48,7 @@ class WhereQueriesTest extends TestCase
         $this->mockIndex(User::class)
             ->shouldReceive('searchSingleIndex')
             ->once()
-            ->with('users', Mockery::subset(['query' => 'foo', 'numericFilters' => ['views_count: 100 TO 200']]))
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => 'views_count: 100 TO 200']))
             ->andReturn(['hits' => []]);
 
         User::search('foo')->whereBetween('views_count', [100, 200])->get();
@@ -75,9 +62,7 @@ class WhereQueriesTest extends TestCase
         $this->mockIndex(User::class)
             ->shouldReceive('searchSingleIndex')
             ->once()
-            ->with('users', Mockery::subset(['query' => 'foo', 'numericFilters' => [
-                "created_at: {$date1->getTimestamp()} TO {$date2->getTimestamp()}",
-            ]]))
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => "created_at: {$date1->getTimestamp()} TO {$date2->getTimestamp()}"]))
             ->andReturn(['hits' => []]);
 
         User::search('foo')->whereBetween('created_at', [$date1, $date2])->get();
@@ -88,9 +73,7 @@ class WhereQueriesTest extends TestCase
         $this->mockIndex(User::class)
             ->shouldReceive('searchSingleIndex')
             ->once()
-            ->with('users', Mockery::subset(['query' => 'foo', 'numericFilters' => [
-                ['id=1', 'id=2', 'id=3', 'id=4'],
-            ]]))
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => '(id=1 OR id=2 OR id=3 OR id=4)']))
             ->andReturn(['hits' => []]);
 
         User::search('foo')->whereIn('id', [1, 2, 3, 4])->get();
@@ -101,9 +84,7 @@ class WhereQueriesTest extends TestCase
         $this->mockIndex(User::class)
             ->shouldReceive('searchSingleIndex')
             ->once()
-            ->with('users', Mockery::subset(['query' => 'foo', 'numericFilters' => [
-                ['0 = 1'],
-            ]]))
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => '(0 = 1)']))
             ->andReturn(['hits' => []]);
 
         User::search('foo')->whereIn('id', [])->get();
@@ -114,10 +95,7 @@ class WhereQueriesTest extends TestCase
         $this->mockIndex(User::class)
             ->shouldReceive('searchSingleIndex')
             ->once()
-            ->with('users', Mockery::subset(['query' => 'foo', 'numericFilters' => [
-                ['id=1', 'id=2'],
-                'key=value',
-            ]]))
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => '(id=1 OR id=2) AND key=value']))
             ->andReturn(['hits' => []]);
 
         User::search('foo')->whereIn('id', [1, 2])->where('key', 'value')->get();


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | yes    
| Related Issue     | Fix #364
| Need Doc update   | yes

## Describe your change

### Upgrade Laravel Scout from v10 to v11 [[API-364]](https://algolia.atlassian.net/browse/API-364)

This PR upgrades laravel/scout from ^10.11.6 to ^11.0.0, removing the legacy numericFilters array-based filtering and replacing it with Scout v11's native filters string syntax. Where conditions are now stored using Scout v11's structured ['field', 'operator', 'value'] format and $whereIns property, removing all manual $wheres manipulation.

### Breaking Changes

- Laravel Scout minimum version raised to ^11.0.0. Scout 10.x is no longer supported. Scout v11 removed numericFilters (https://github.com/laravel/scout/pull/839) in favour of the filters string parameter.
- filters() return type changed from array to string. Any subclass overriding filters() must be updated to return a boolean expression string (e.g. field > 100 AND (id=1 OR id=2)) instead of an array.
- The engine now uses the `filters` key instead of `numericFilters`. Any manual `->with(['filters' => '...'])` call will be **overwritten** by the engine's computed filters. Users combining `->with(['filters' => ...])` alongside `where()` clauses need to move all filter conditions into `where()` / `whereIn()` / `whereNotIn()` calls instead.

[API-364]: https://algolia.atlassian.net/browse/API-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ