### PR TITLE
use arrays for operationIndex() to resolve array_merge TypeError

### DIFF
--- a/src/Console/Commands/ReImportCommand.php
+++ b/src/Console/Commands/ReImportCommand.php
@@ -15,7 +15,6 @@ namespace Algolia\ScoutExtended\Console\Commands;
 
 use Algolia\AlgoliaSearch\Api\SearchClient;
 use Algolia\AlgoliaSearch\Exceptions\NotFoundException;
-use Algolia\AlgoliaSearch\Model\Search\OperationIndexParams;
 use Algolia\AlgoliaSearch\Model\Search\OperationType;
 use Algolia\AlgoliaSearch\Model\Search\ScopeType;
 use Algolia\ScoutExtended\Helpers\SearchableFinder;
@@ -65,13 +64,11 @@ class ReImportCommand extends Command
             try {
                 $client->getSettings($indexName);
 
-                $response = $client->operationIndex(
-                    $indexName,
-                    (new OperationIndexParams())
-                        ->setOperation(OperationType::COPY) // @phpstan-ignore argument.type (generated client uses string constants typed as class)
-                        ->setDestination($temporaryName)
-                        ->setScope([ScopeType::SETTINGS, ScopeType::SYNONYMS, ScopeType::RULES]) // @phpstan-ignore argument.type (generated client uses string constants typed as class)
-                );
+                $response = $client->operationIndex($indexName, [
+                    'operation' => OperationType::COPY,
+                    'destination' => $temporaryName,
+                    'scope' => [ScopeType::SETTINGS, ScopeType::SYNONYMS, ScopeType::RULES],
+                ]);
                 $client->waitForTask($temporaryName, $response['taskID']);
             } catch (NotFoundException $e) {
                 // ..
@@ -98,12 +95,10 @@ class ReImportCommand extends Command
             try {
                 $client->getSettings($temporaryName);
 
-                $response = $client->operationIndex(
-                    $temporaryName,
-                    (new OperationIndexParams())
-                        ->setOperation(OperationType::MOVE) // @phpstan-ignore argument.type (generated client uses string constants typed as class)
-                        ->setDestination($indexName)
-                );
+                $response = $client->operationIndex($temporaryName, [
+                    'operation' => OperationType::MOVE,
+                    'destination' => $indexName,
+                ]);
 
                 if ($config->get('scout.synchronous', false)) {
                     $client->waitForTask($indexName, $response['taskID']);

--- a/tests/Features/ReimportCommandTest.php
+++ b/tests/Features/ReimportCommandTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Features;
 
-use Algolia\AlgoliaSearch\Model\Search\OperationIndexParams;
+use Algolia\AlgoliaSearch\Model\Search\OperationType;
+use Algolia\AlgoliaSearch\Model\Search\ScopeType;
 use App\User;
 use Illuminate\Support\Facades\Artisan;
 use Mockery;
@@ -27,13 +28,22 @@ class ReimportCommandTest extends TestCase
         // getSettings for temp index (called after import to verify it exists)
         $client->shouldReceive('getSettings')->with($temporaryName)->andReturn([]);
 
-        // operationIndex handles both copy and move
+        // operationIndex: copy settings from main to temp
         $client->shouldReceive('operationIndex')
-            ->with($indexName, Mockery::type(OperationIndexParams::class))
+            ->with($indexName, Mockery::on(function ($params) use ($temporaryName) {
+                return is_array($params)
+                    && $params['operation'] === OperationType::COPY
+                    && $params['destination'] === $temporaryName
+                    && $params['scope'] === [ScopeType::SETTINGS, ScopeType::SYNONYMS, ScopeType::RULES];
+            }))
             ->andReturn(['taskID' => 1]);
 
         $client->shouldReceive('operationIndex')
-            ->with($temporaryName, Mockery::type(OperationIndexParams::class))
+            ->with($temporaryName, Mockery::on(function ($params) use ($indexName) {
+                return is_array($params)
+                    && $params['operation'] === OperationType::MOVE
+                    && $params['destination'] === $indexName;
+            }))
             ->andReturn(['taskID' => 1]);
 
         // saveObjects called by makeAllSearchable() via UpdateJob for the temp index


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | Fix #366
| Need Doc update   | no

## Describe your change

Replaced both `operationIndex()` calls with plain `arrays`, which matches the client's expected input format.

## What problem is this fixing?

`ReImportCommand` passed `OperationIndexParams` model objects to `SearchClient::operationIndex()`, but the generated client internally calls `array_merge()` on that argument, causing a `TypeError` at runtime.

Although the client still claims to accept `OperationIndexParams`, that path is broken. The proposed fix resolves the issue with the reimport. I will open an issue with the Algolia client too.