### PR TITLE
feat: enhance Algolia filter syntax for string and boolean values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Filter values are now formatted according to Algolia's filter grammar ([#368](https://github.com/algolia/scout-extended/pull/368)). Strings use the quoted facet form (`where('group', 'primary-vehicle')` → `group:'primary-vehicle'`, with quotes/backslashes escaped), booleans use `field:true` / `field:false`, and numbers keep `=` / `!=`. `whereNotIn` now emits one `NOT` clause per value instead of the invalid `NOT (... OR ...)` form.
 
 ## [5.0.0](https://github.com/algolia/scout-extended/compare/v4.0.0...v5.0.0) - 2026-04-28
 ### Changed

--- a/src/Engines/AlgoliaEngine.php
+++ b/src/Engines/AlgoliaEngine.php
@@ -91,24 +91,66 @@ class AlgoliaEngine extends Algolia4Engine
         foreach ($builder->whereIns as $field => $values) {
             $parts[] = empty($values)
                 ? '(0 = 1)'
-                : '('.implode(' OR ', array_map(fn ($v) => "$field=$v", $values)).')';
+                : '('.implode(' OR ', array_map(fn ($value) => $this->formatFilter($field, $value), $values)).')';
         }
 
         foreach ($builder->whereNotIns as $field => $values) {
-            if (! empty($values)) {
-                $parts[] = 'NOT ('.implode(' OR ', array_map(fn ($v) => "$field=$v", $values)).')';
+            // Algolia's filter grammar cannot negate a parenthesized group:
+            // NOT binds to a single clause, so each value is negated individually.
+            foreach ($values as $value) {
+                $parts[] = 'NOT '.$this->formatFilter($field, $value);
             }
         }
 
         foreach ($builder->wheres as ['field' => $field, 'operator' => $operator, 'value' => $value]) {
             $parts[] = match ($operator) {
                 ':' => "$field: {$value[0]} TO {$value[1]}",
-                '=' => "$field=$value",
+                '=' => $this->formatFilter($field, $value),
+                '!=' => $this->formatNegatedFilter($field, $value),
                 default => "$field $operator $value",
             };
         }
 
         return implode(' AND ', $parts);
+    }
+
+    /**
+     * Format an equality filter in Algolia's filter syntax.
+     *
+     * Algolia reserves "=" for numeric comparisons, so strings and booleans
+     * must use the facet form "field:value", with string values quoted and
+     * escaped. Numeric values (including numeric strings, which Algolia
+     * compares numerically) keep the "=" operator.
+     */
+    private function formatFilter(string $field, mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $field.':'.($value ? 'true' : 'false');
+        }
+
+        if ($this->isNonNumericString($value)) {
+            return $field.":'".str_replace(['\\', "'"], ['\\\\', "\\'"], $value)."'";
+        }
+
+        return "$field=$value";
+    }
+
+    /**
+     * Format a negated equality filter, keeping Algolia's native "!="
+     * operator for numeric values.
+     */
+    private function formatNegatedFilter(string $field, mixed $value): string
+    {
+        if (is_bool($value) || $this->isNonNumericString($value)) {
+            return 'NOT '.$this->formatFilter($field, $value);
+        }
+
+        return "$field != $value";
+    }
+
+    private function isNonNumericString(mixed $value): bool
+    {
+        return is_string($value) && ! is_numeric($value);
     }
 
     /**

--- a/tests/Features/WhereQueriesTest.php
+++ b/tests/Features/WhereQueriesTest.php
@@ -95,9 +95,86 @@ class WhereQueriesTest extends TestCase
         $this->mockIndex(User::class)
             ->shouldReceive('searchSingleIndex')
             ->once()
-            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => '(id=1 OR id=2) AND key=value']))
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => "(id=1 OR id=2) AND key:'value'"]))
             ->andReturn(['hits' => []]);
 
         User::search('foo')->whereIn('id', [1, 2])->where('key', 'value')->get();
+    }
+
+    public function testWhereWithStringValue(): void
+    {
+        $this->mockIndex(User::class)
+            ->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => "group:'primary-vehicle'"]))
+            ->andReturn(['hits' => []]);
+
+        User::search('foo')->where('group', 'primary-vehicle')->get();
+    }
+
+    public function testWhereWithStringValueEscapesQuotesAndBackslashes(): void
+    {
+        $this->mockIndex(User::class)
+            ->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => "name:'O\\'Brian \\\\ Co'"]))
+            ->andReturn(['hits' => []]);
+
+        User::search('foo')->where('name', "O'Brian \\ Co")->get();
+    }
+
+    public function testWhereWithBooleanValue(): void
+    {
+        $this->mockIndex(User::class)
+            ->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => 'active:true AND archived:false']))
+            ->andReturn(['hits' => []]);
+
+        User::search('foo')->where('active', true)->where('archived', false)->get();
+    }
+
+    public function testWhereNotEqualWithStringValue(): void
+    {
+        $this->mockIndex(User::class)
+            ->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => "NOT group:'witness'"]))
+            ->andReturn(['hits' => []]);
+
+        User::search('foo')->where('group', '!=', 'witness')->get();
+    }
+
+    public function testWhereInWithStringValues(): void
+    {
+        $this->mockIndex(User::class)
+            ->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => "(visible_by:'workspace/80' OR visible_by:'workspace/64')"]))
+            ->andReturn(['hits' => []]);
+
+        User::search('foo')->whereIn('visible_by', ['workspace/80', 'workspace/64'])->get();
+    }
+
+    public function testWhereNotIn(): void
+    {
+        $this->mockIndex(User::class)
+            ->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => 'NOT id=1 AND NOT id=2']))
+            ->andReturn(['hits' => []]);
+
+        User::search('foo')->whereNotIn('id', [1, 2])->get();
+    }
+
+    public function testWhereNotInWithStringValues(): void
+    {
+        $this->mockIndex(User::class)
+            ->shouldReceive('searchSingleIndex')
+            ->once()
+            ->with('users', Mockery::subset(['query' => 'foo', 'filters' => "NOT group:'witness' AND NOT group:'third-party'"]))
+            ->andReturn(['hits' => []]);
+
+        User::search('foo')->whereNotIn('group', ['witness', 'third-party'])->get();
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no/not sure
| BC breaks?        | no
| Related Issue     | Fix #315
| Need Doc update   | no/not sure

## Describe your change

`AlgoliaEngine::filters()` now formats `where` / `whereIn` / `whereNotIn` values according to Algolia's filter grammar instead of always emitting `field=value`:

- **Strings** use the facet form with quoting and escaping: `where('group', 'primary-vehicle')` → `group:'primary-vehicle'`. Single quotes and backslashes in the value are escaped (`O'Brian \ Co` → `name:'O\'Brian \\ Co'`).
- **Booleans** use the facet form: `where('active', true)` → `active:true`.
- **Numbers** (and numeric strings, which Algolia compares numerically) keep the numeric operator: `where('id', 1)` → `id=1`.
- **`!=`** keeps Algolia's native operator for numbers (`id != 1`) and becomes `NOT field:value` for strings/booleans.
- **`whereNotIn`** emits one negated clause per value (`NOT group:'witness' AND NOT group:'third-party'`) instead of `NOT (... OR ...)`, because Algolia's grammar cannot negate a parenthesized group — `NOT` binds to a single clause.

## What problem is this fixing?

Algolia reserves `=` for numeric comparisons. Filtering on a string or boolean attribute — e.g. `User::search('foo')->where('group', 'primary-vehicle')` — produced `group=primary-vehicle`, which Algolia rejects/mismatches because string facets must be expressed as `group:'primary-vehicle'`. The same applied to `whereIn` with string values, and `whereNotIn` additionally produced the invalid `NOT (a OR b)` form.

This closes the remaining pain in #315: `whereNotIn` itself shipped in v5.0.0, but string values still produced numeric-only syntax (`status!=archived`), forcing manual `status:-archived` facet-filter workarounds. Both `whereNotIn('status', ['archived'])` and `where('status', '!=', 'archived')` now emit valid `NOT status:'archived'` filters.

Covered by 7 new tests in `WhereQueriesTest`; every added executable line in `AlgoliaEngine.php` is exercised (100% patch coverage). Full suite: 92 tests, 368 assertions, PHPStan clean.
